### PR TITLE
Add function definitions

### DIFF
--- a/data-queryable.d.ts
+++ b/data-queryable.d.ts
@@ -15,7 +15,7 @@ export declare class DataQueryable implements DataContextEmitter {
     equal(value: any): DataQueryable;
     notEqual(value: any): DataQueryable;
     greaterThan(value: any): DataQueryable;
-    greaterOEqual(value: any): DataQueryable;
+    greaterOrEqual(value: any): DataQueryable;
     bit(value: any, result?:number): DataQueryable;
     lowerThan(value: any): DataQueryable;
     lowerOrEqual(value: any): DataQueryable;

--- a/data-queryable.d.ts
+++ b/data-queryable.d.ts
@@ -14,6 +14,8 @@ export declare class DataQueryable implements DataContextEmitter {
     is(value: any): DataQueryable;
     equal(value: any): DataQueryable;
     notEqual(value: any): DataQueryable;
+    in(...attr: any[]): DataQueryable;
+    notIn(...attr: any[]): DataQueryable;
     greaterThan(value: any): DataQueryable;
     greaterOrEqual(value: any): DataQueryable;
     bit(value: any, result?:number): DataQueryable;


### PR DESCRIPTION
This corrects the function declarations of `greaterOrEqual` and adds `in` and `notIn`. This would help intellisense suggest the correct function and not complain about the other functions
 