### PR TITLE
Add migrate async

### DIFF
--- a/data-configuration.js
+++ b/data-configuration.js
@@ -685,7 +685,7 @@ SchemaLoaderStrategy.prototype.setModelDefinition = function(data) {
         if (typeof data.name === 'undefined' || data.name === null) {
             throw new Error("Invalid model definition. Expected model name.")
         }
-        this[modelsProperty][data.name] = data;
+        this[modelsProperty][data.name] = _.cloneDeep(data);
     }
     return this;
 };

--- a/data-configuration.js
+++ b/data-configuration.js
@@ -685,7 +685,7 @@ SchemaLoaderStrategy.prototype.setModelDefinition = function(data) {
         if (typeof data.name === 'undefined' || data.name === null) {
             throw new Error("Invalid model definition. Expected model name.")
         }
-        this[modelsProperty][data.name] = _.cloneDeep(data);
+        this[modelsProperty][data.name] = data;
     }
     return this;
 };
@@ -836,14 +836,16 @@ FileSchemaLoaderStrategy.prototype.getModelDefinition = function(name) {
     for (i = 0; i < files.length; i++) {
         searchName.lastIndex=0;
         if (searchName.test(files[i])) {
-            //build model file path
+            // build model file path
             var finalPath = PathUtils.join(modelPath, files[i]);
-            //get model
+            // get model
             var result = require(finalPath);
-            //set definition
-            this.setModelDefinition(result);
-            //and finally return this definition
-            return result;
+            // clone
+            var finalResult = _.cloneDeep(result);
+            // clone and set definition
+            this.setModelDefinition(finalResult);
+            // return this definition
+            return finalResult;
         }
     }
 };

--- a/data-context.d.ts
+++ b/data-context.d.ts
@@ -5,7 +5,7 @@ export declare class DefaultDataContext extends DataContext {
     constructor();
     readonly name: string;
     getDb(): DataAdapter;
-    setDb(db: DataAdapter);
+    setDb(db: DataAdapter): void;
 }
 
 export declare class NamedDataContext extends DataContext {
@@ -13,5 +13,5 @@ export declare class NamedDataContext extends DataContext {
     readonly name: string;
     getName(): string
     getDb(): DataAdapter;
-    setDb(db: DataAdapter);
+    setDb(db: DataAdapter): void;
 }

--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -54,6 +54,7 @@ export declare class DataModel extends SequentialEventEmitter{
     insert(obj: any): Promise<any>;
     remove(obj: any): Promise<any>;
     migrate(callback: (err?: Error, res?: any) => void): void;
+    migrateAsync(): Promise<void>;
     key(): any;
     field(name: string): DataField;
     getDataView(name: string): any;

--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -53,8 +53,8 @@ export declare class DataModel extends SequentialEventEmitter{
     update(obj: any): Promise<any>;
     insert(obj: any): Promise<any>;
     remove(obj: any): Promise<any>;
-    migrate(callback: (err?: Error, res?: any) => void): void;
-    migrateAsync(): Promise<void>;
+    migrate(callback: (err?: Error, res?: boolean) => void): void;
+    migrateAsync(): Promise<boolean>;
     key(): any;
     field(name: string): DataField;
     getDataView(name: string): any;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,569 @@
 {
   "name": "@themost/data",
   "version": "2.6.11",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@themost/data",
+      "version": "2.6.11",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "async": "0.2.10",
+        "lodash": "^4.17.21",
+        "moment": "^2.19.3",
+        "node-cache": "^1.1.0",
+        "object-hash": "^1.3.1",
+        "pluralize": "^7.0.0",
+        "q": "^1.4.1",
+        "sprintf": "^0.1.5",
+        "symbol": "^0.3.1"
+      },
+      "devDependencies": {
+        "@themost/peers": "^1.0.2",
+        "@types/core-js": "^2.5.0",
+        "@types/jasmine": "^3.6.4",
+        "@types/lodash": "^4.14.149",
+        "@types/node": "^10.12.0",
+        "@types/pluralize": "0.0.29",
+        "@types/q": "^1.5.1",
+        "@types/sql.js": "^1.4.0",
+        "jasmine": "^3.6.4",
+        "jasmine-spec-reporter": "^6.0.0",
+        "sql.js": "^1.4.0",
+        "ts-node": "^9.1.1",
+        "typescript": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@themost/common": ">= 2.5.2 < 3",
+        "@themost/query": ">= 2.5.1 < 3",
+        "@themost/xml": ">= 2.5.1 < 3"
+      }
+    },
+    "node_modules/@themost/common": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@themost/common/-/common-2.5.6.tgz",
+      "integrity": "sha512-MiGeve+SOUl0UeOLoZYfqxg9Ban33uQZ0fpP64B1Qdq12bteHUUZgu2QWuD3kNJPY2cP66u/gXrpE8ux+/nanA==",
+      "peer": true,
+      "dependencies": {
+        "async": "^2.6.3",
+        "blueimp-md5": "^2.7.0",
+        "es6-promise": "^4.2.8",
+        "events": "^3.2.0",
+        "hashmap": "^2.3.0",
+        "lodash": "^4.17.20",
+        "sprintf": "^0.1.5",
+        "symbol": "^0.3.1"
+      }
+    },
+    "node_modules/@themost/common/node_modules/async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "peer": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/@themost/peers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@themost/peers/-/peers-1.0.2.tgz",
+      "integrity": "sha512-D/i8ONz7dgzWOa/SCoodPCg/yb5C8UQaB5T0Ob2yauLtCHR+OVbrgBnAtqQxxSM0w6cWrvPEycQTqO1Ldn4vbg==",
+      "dev": true,
+      "bin": {
+        "add-peers": "bin/add-peers"
+      }
+    },
+    "node_modules/@themost/query": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.5.1.tgz",
+      "integrity": "sha512-AlDIZpo74k3P4sSkMvsQ/72Dh3joPxYtxoXTajUNRVwlhnADpwj2vyDasVmqMiY1T1CRVjNPF6sV35u64czeNQ==",
+      "peer": true,
+      "dependencies": {
+        "async": "0.2.10",
+        "esprima": "^4.0.0",
+        "lodash": "^4.17.15",
+        "sprintf": "^0.1.5",
+        "symbol": "^0.3.1"
+      },
+      "peerDependencies": {
+        "@themost/common": "^2.5.0"
+      }
+    },
+    "node_modules/@themost/xml": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@themost/xml/-/xml-2.5.2.tgz",
+      "integrity": "sha512-J3qXDJ/Rey5Tri8Swb4ghF7TRaoQ4NXjCsXiyf1GKNAhN4nn4XtfMwIhsrN9LI5z9TUZOut6LOK9PMWDVWRrpA==",
+      "peer": true
+    },
+    "node_modules/@types/core-js": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-2.5.0.tgz",
+      "integrity": "sha512-qjkHL3wF0JMHMqgm/kmL8Pf8rIiqvueEiZ0g6NVTcBX1WN46GWDr+V5z+gsHUeL0n8TfAmXnYmF7ajsxmBp4PQ==",
+      "dev": true
+    },
+    "node_modules/@types/emscripten": {
+      "version": "1.39.4",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.4.tgz",
+      "integrity": "sha512-k3LLVMFrdNA9UCvMDPWMbFrGPNb+GcPyw29ktJTo1RCN7RmxFG5XzPZcPKRlnLuLT/FRm8wp4ohvDwNY7GlROQ==",
+      "dev": true
+    },
+    "node_modules/@types/jasmine": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.6.4.tgz",
+      "integrity": "sha512-CTdMERA4iGNcxeqzD7pavb4WLIFq6bGnx6nIJD+1D4Knx24GE6QBPrWVhO8UlIy7gf7rbIt3ZD7iIzryRD2TgA==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "10.12.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.30.tgz",
+      "integrity": "sha512-nsqTN6zUcm9xtdJiM9OvOJ5EF0kOI8f1Zuug27O/rgtxCRJHGqncSWfCMZUP852dCKPsDsYXGvBhxfRjDBkF5Q==",
+      "dev": true
+    },
+    "node_modules/@types/pluralize": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.29.tgz",
+      "integrity": "sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==",
+      "dev": true
+    },
+    "node_modules/@types/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA==",
+      "dev": true
+    },
+    "node_modules/@types/sql.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.0.tgz",
+      "integrity": "sha512-SGleBhOHh/T78HP/O5Py4EwEgCIlY+0WwbmY8u/meyVLC1X7sNOnEYZY4qTKpXvU+jpJXFCSPgSX+++JqQt4NQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/emscripten": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/blueimp-md5": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
+      "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
+      "peer": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "peer": true
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "peer": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/hashmap": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/hashmap/-/hashmap-2.4.0.tgz",
+      "integrity": "sha512-Ngj48lhnxJdnBAEVbubKBJuN1elfVLZJs94ZixRi98X3GCU4v6pgj9qRkHt6H8WaVJ69Wv0r1GhtS7hvF9zCgg==",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/jasmine": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.6.4.tgz",
+      "integrity": "sha512-hIeOou6y0BgCOKYgXYveQvlY+PTHgDPajFf+vLCYbMTQ+VjAP9+EQv0nuC9+gyCAAWISRFauB1XUb9kFuOKtcQ==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.6",
+        "jasmine-core": "~3.6.0"
+      },
+      "bin": {
+        "jasmine": "bin/jasmine.js"
+      }
+    },
+    "node_modules/jasmine-core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.6.0.tgz",
+      "integrity": "sha512-8uQYa7zJN8hq9z+g8z1bqCfdC8eoDAeVnM5sfqs7KHv9/ifoJ500m018fpFc7RDaO6SWCLCXwo/wPSNcdYTgcw==",
+      "dev": true
+    },
+    "node_modules/jasmine-spec-reporter": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-6.0.0.tgz",
+      "integrity": "sha512-MvTOVoMxDZAftQYBApIlSfKnGMzi9cj351nXeqtnZTuXffPlbONN31+Es7F+Ke4okUeQ2xISukt4U1npfzLVrQ==",
+      "dev": true,
+      "dependencies": {
+        "colors": "1.4.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/node-cache": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-1.1.0.tgz",
+      "integrity": "sha1-GGNlAy0jlb3/c0BBePsryJgaznA=",
+      "dependencies": {
+        "underscore": "*"
+      },
+      "engines": {
+        "node": ">= 0.4.6"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.1.tgz",
+      "integrity": "sha512-OSuu/pU4ENM9kmREg0BdNrUDIl1heYa4mBZacJc+vVWz4GtAwu7jO8s4AIt2aGRUTqxykpWzI3Oqnsm13tTMDA==",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/sprintf/-/sprintf-0.1.5.tgz",
+      "integrity": "sha1-j4PjmpMXwaUCy324BQ5Rxnn27c8=",
+      "deprecated": "The sprintf package is deprecated in favor of sprintf-js.",
+      "engines": {
+        "node": ">=0.2.4"
+      }
+    },
+    "node_modules/sql.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.4.0.tgz",
+      "integrity": "sha512-lm9x8M6O1kXjSieP/Z8Zayh+ksHN78TYX7pSh0UR1GjSVx5Kp1r+bo+l4s44rcpb0002i25f+QC4FYtfqr3lYQ==",
+      "dev": true
+    },
+    "node_modules/symbol": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.3.1.tgz",
+      "integrity": "sha1-tvmpANSWpX8CQI8iGYwQndoGMEE="
+    },
+    "node_modules/ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dev": true,
+      "dependencies": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g=="
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
   "dependencies": {
+    "@themost/common": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@themost/common/-/common-2.5.6.tgz",
+      "integrity": "sha512-MiGeve+SOUl0UeOLoZYfqxg9Ban33uQZ0fpP64B1Qdq12bteHUUZgu2QWuD3kNJPY2cP66u/gXrpE8ux+/nanA==",
+      "peer": true,
+      "requires": {
+        "async": "^2.6.3",
+        "blueimp-md5": "^2.7.0",
+        "es6-promise": "^4.2.8",
+        "events": "^3.2.0",
+        "hashmap": "^2.3.0",
+        "lodash": "^4.17.20",
+        "sprintf": "^0.1.5",
+        "symbol": "^0.3.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "peer": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        }
+      }
+    },
+    "@themost/peers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@themost/peers/-/peers-1.0.2.tgz",
+      "integrity": "sha512-D/i8ONz7dgzWOa/SCoodPCg/yb5C8UQaB5T0Ob2yauLtCHR+OVbrgBnAtqQxxSM0w6cWrvPEycQTqO1Ldn4vbg==",
+      "dev": true
+    },
+    "@themost/query": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.5.1.tgz",
+      "integrity": "sha512-AlDIZpo74k3P4sSkMvsQ/72Dh3joPxYtxoXTajUNRVwlhnADpwj2vyDasVmqMiY1T1CRVjNPF6sV35u64czeNQ==",
+      "peer": true,
+      "requires": {
+        "async": "0.2.10",
+        "esprima": "^4.0.0",
+        "lodash": "^4.17.15",
+        "sprintf": "^0.1.5",
+        "symbol": "^0.3.1"
+      }
+    },
+    "@themost/xml": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@themost/xml/-/xml-2.5.2.tgz",
+      "integrity": "sha512-J3qXDJ/Rey5Tri8Swb4ghF7TRaoQ4NXjCsXiyf1GKNAhN4nn4XtfMwIhsrN9LI5z9TUZOut6LOK9PMWDVWRrpA==",
+      "peer": true
+    },
     "@types/core-js": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-2.5.0.tgz",
@@ -73,6 +633,12 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "blueimp-md5": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
+      "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
+      "peer": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -113,6 +679,24 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
     },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "peer": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "peer": true
+    },
+    "events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "peer": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -132,6 +716,12 @@
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
+    },
+    "hashmap": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/hashmap/-/hashmap-2.4.0.tgz",
+      "integrity": "sha512-Ngj48lhnxJdnBAEVbubKBJuN1elfVLZJs94ZixRi98X3GCU4v6pgj9qRkHt6H8WaVJ69Wv0r1GhtS7hvF9zCgg==",
+      "peer": true
     },
     "inflight": {
       "version": "1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/pluralize": "0.0.29",
         "@types/q": "^1.5.1",
         "@types/sql.js": "^1.4.0",
+        "dotenv": "^16.0.0",
         "jasmine": "^3.6.4",
         "jasmine-spec-reporter": "^6.0.0",
         "sql.js": "^1.4.0",
@@ -218,6 +219,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/es6-promise": {
@@ -677,6 +687,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
+    "dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
       "dev": true
     },
     "es6-promise": {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "main": "index.js",
   "scripts": {
     "test": "jasmine",
-    "install-peers": "npm-install-peers"
+    "install-peers": "add-peers"
   },
   "peerDependencies": {
     "@themost/common": ">= 2.5.2 < 3",
-    "@themost/query": ">= 2.5.0 < 3",
+    "@themost/query": ">= 2.5.1 < 3",
     "@themost/xml": ">= 2.5.1 < 3"
   },
   "engines": {
@@ -37,6 +37,7 @@
     "symbol": "^0.3.1"
   },
   "devDependencies": {
+    "@themost/peers": "^1.0.2",
     "@types/core-js": "^2.5.0",
     "@types/jasmine": "^3.6.4",
     "@types/lodash": "^4.14.149",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/pluralize": "0.0.29",
     "@types/q": "^1.5.1",
     "@types/sql.js": "^1.4.0",
+    "dotenv": "^16.0.0",
     "jasmine": "^3.6.4",
     "jasmine-spec-reporter": "^6.0.0",
     "sql.js": "^1.4.0",

--- a/spec/DataModel.spec.ts
+++ b/spec/DataModel.spec.ts
@@ -1,6 +1,7 @@
 import {DataModel, EdmMapping, DataContext} from '../index';
 import { TestApplication } from './TestApplication';
 import { resolve } from 'path';
+import { TestAdapter } from './adapter/TestAdapter';
 
 class Employee {
     public EmployeeID?: number;
@@ -64,6 +65,15 @@ describe('DataModel', () => {
         let item: Employee = await context.model(Employee).where('EmployeeID').equal(1).getItem();
         expect(item).toBeTruthy();
         expect(item.EmployeeID).toBe(1);
+    });
+
+    it('should use migrateAsync', async () => {
+        const db: TestAdapter = context.db as TestAdapter;
+        let exists = await db.table('OtherProducts').existsAsync();
+        expect(exists).toBeFalse();
+        await context.model('OtherProduct').migrateAsync();
+        exists = await db.table('OtherProducts').existsAsync();
+        expect(exists).toBeTruthy();
     });
 
 });

--- a/spec/DataModel.spec.ts
+++ b/spec/DataModel.spec.ts
@@ -71,9 +71,16 @@ describe('DataModel', () => {
         const db: TestAdapter = context.db as TestAdapter;
         let exists = await db.table('OtherProducts').existsAsync();
         expect(exists).toBeFalse();
-        await context.model('OtherProduct').migrateAsync();
+        const upgraded = await context.model('OtherProduct').migrateAsync();
+        expect(upgraded).toBeTrue();
         exists = await db.table('OtherProducts').existsAsync();
         expect(exists).toBeTruthy();
+        const configuration: any = app.getConfiguration();
+        expect(configuration.cache).toBeInstanceOf(Object);
+        const version = context.model('OtherProduct').version;
+        expect(configuration.cache.OtherProduct).toEqual({
+            version
+        });
     });
 
 });

--- a/spec/DataNestedObjectListener.spec.ts
+++ b/spec/DataNestedObjectListener.spec.ts
@@ -31,53 +31,6 @@ describe('DataNestedObjectListener', () => {
     });
     it('should use zero-or-one multiplicity', async () => {
         await context.executeInTransactionAsync(async () => {
-            const configuration = context.getConfiguration().getStrategy(DataConfigurationStrategy);
-            configuration.setModelDefinition({
-                "name": "ProductDimension",
-                "version": "2.0",
-                "inherits": "StructuredValue",
-                "fields": [
-                    {
-                        "name": "width",
-                        "type": "Number",
-                        "nullable": false
-                    },
-                    {
-                        "name": "height",
-                        "type": "Number",
-                        "nullable": false
-                    },
-                    {
-                        "name": "product",
-                        "type": "Product"
-                    }
-                ],
-                "constraints": [
-                    {
-                        "type": "unique",
-                        "fields": [
-                            "product"
-                        ]
-                    }
-                ]
-            });
-            const ProductModel = configuration.getModelDefinition("Product");
-            ProductModel.fields.push({
-                "name": "productDimensions",
-                "type": "ProductDimension",
-                "nested": true,
-                "expandable": true,
-                "multiplicity": "ZeroOrOne",
-                "mapping": {
-                    "parentModel": "Product",
-                    "parentField": "id",
-                    "childModel": "ProductDimension",
-                    "childField": "product",
-                    "associationType": "association",
-                    "cascade": "delete"
-                }
-            });
-            configuration.setModelDefinition(ProductModel);
             let product = await context.model('Product')
                 .where('name').equal('Samsung Galaxy S4')
                 .silent().getItem();
@@ -105,41 +58,7 @@ describe('DataNestedObjectListener', () => {
 
     it('should use collection of nested objects', async () => {
         await context.executeInTransactionAsync(async () => {
-            const configuration = context.getConfiguration().getStrategy(DataConfigurationStrategy);
-            configuration.setModelDefinition({
-                "name": "SpecialOffer",
-                "version": "2.0",
-                "inherits": "Offer",
-                "fields": [
-                    {
-                        "@id": "http://schema.org/itemOffered",
-                        "name": "itemOffered",
-                        "title": "itemOffered",
-                        "description": "The item being offered.",
-                        "type": "Product",
-                        "nullable": false
-                    }
-                ],
-                "constraints": [
-                ]
-            });
-            const ProductModel = configuration.getModelDefinition("Product");
-            ProductModel.fields.push({
-                "name": "specialOffers",
-                "type": "SpecialOffer",
-                "nested": true,
-                "expandable": true,
-                "many": true,
-                "mapping": {
-                    "parentModel": "Product",
-                    "parentField": "id",
-                    "childModel": "SpecialOffer",
-                    "childField": "itemOffered",
-                    "associationType": "association",
-                    "cascade": "delete"
-                }
-            });
-            configuration.setModelDefinition(ProductModel);
+            
             let product = await context.model('Product')
                 .where('name').equal('Samsung Galaxy S4')
                 .silent().getItem();

--- a/spec/DataObjectAssociationListener.spec.ts
+++ b/spec/DataObjectAssociationListener.spec.ts
@@ -2,6 +2,7 @@ import { TestApplication } from './TestApplication';
 import { DataContext, DataObjectAssociationError } from '../index';
 import { resolve } from 'path';
 import { TestUtils } from './adapter/TestUtils';
+import { ConfigurationBase } from '@themost/common';
 
 describe('DataObjectAssociationListener', () => {
     let app: TestApplication;

--- a/spec/DataObjectAssociationListener.spec.ts
+++ b/spec/DataObjectAssociationListener.spec.ts
@@ -32,7 +32,8 @@ describe('DataObjectAssociationListener', () => {
     });
     it('should validate foreign-key association', async ()=> {
         await TestUtils.executeInTransaction(context, async () => {
-            const product = await context.model('Product')
+            const Products = context.model('Product');
+            const product = await Products
                 .where('name').equal('Samsung Galaxy S4')
                 .getItem();
             let newOffer: any = {

--- a/spec/helpers/env.js
+++ b/spec/helpers/env.js
@@ -1,0 +1,4 @@
+const path = require('path');
+require('dotenv').config({
+    path: path.resolve(__dirname, '../.env')
+});

--- a/spec/test1/config/models/OtherProduct.json
+++ b/spec/test1/config/models/OtherProduct.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://themost-framework.github.io/themost/models/2018/2/schema.json",
+    "title": "OtherProducts",
+    "name": "OtherProduct",
+    "source": "OtherProducts",
+    "view": "OtherProducts",
+    "version": "1.0",
+    "inherits": "Product",
+    "fields": [
+        
+    ]
+}

--- a/spec/test2/config/models/Product.json
+++ b/spec/test2/config/models/Product.json
@@ -70,7 +70,37 @@
                 "associationObjectField": "product",
                 "associationValueField": "value"
             }
-        }
+        },
+            {
+                "name": "productDimensions",
+                "type": "ProductDimension",
+                "nested": true,
+                "expandable": true,
+                "multiplicity": "ZeroOrOne",
+                "mapping": {
+                    "parentModel": "Product",
+                    "parentField": "id",
+                    "childModel": "ProductDimension",
+                    "childField": "product",
+                    "associationType": "association",
+                    "cascade": "delete"
+                }
+            },
+            {
+                "name": "specialOffers",
+                "type": "SpecialOffer",
+                "nested": true,
+                "expandable": true,
+                "many": true,
+                "mapping": {
+                    "parentModel": "Product",
+                    "parentField": "id",
+                    "childModel": "SpecialOffer",
+                    "childField": "itemOffered",
+                    "associationType": "association",
+                    "cascade": "delete"
+                }
+            }
     ],
     "constraints": [
         {

--- a/spec/test2/config/models/ProductDimension.json
+++ b/spec/test2/config/models/ProductDimension.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://themost-framework.github.io/themost/models/2018/2/schema.json",
+    "name": "ProductDimension",
+    "version": "2.0",
+    "inherits": "StructuredValue",
+    "fields": [
+        {
+            "name": "width",
+            "type": "Number",
+            "nullable": false
+        },
+        {
+            "name": "height",
+            "type": "Number",
+            "nullable": false
+        },
+        {
+            "name": "product",
+            "type": "Product"
+        }
+    ],
+    "constraints": [
+        {
+            "type": "unique",
+            "fields": [
+                "product"
+            ]
+        }
+    ]
+}

--- a/spec/test2/config/models/SpecialOffer.json
+++ b/spec/test2/config/models/SpecialOffer.json
@@ -1,0 +1,17 @@
+{
+    "name": "SpecialOffer",
+    "version": "2.0",
+    "inherits": "Offer",
+    "fields": [
+        {
+            "@id": "http://schema.org/itemOffered",
+            "name": "itemOffered",
+            "title": "itemOffered",
+            "description": "The item being offered.",
+            "type": "Product",
+            "nullable": false
+        }
+    ],
+    "constraints": [
+    ]
+}


### PR DESCRIPTION
This PR adds `DataModel.migrateAsync()` method for upgrading data models within `async/await` procedures e.g. `await model.migrateAsyc()`

