### PR TITLE
add DataModel.upsert() method

### DIFF
--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -68,4 +68,7 @@ export declare class DataModel extends SequentialEventEmitter{
     getTypedItems(): Promise<DataObject|any>;
     getItems(): Promise<any>;
     getTypedList():Promise<any>;
+    upsert(obj: any | Array<any>): Promise<any>;
+    upsert(obj: any | Array<any>, callback: (err?: Error, result?: any) => void): void;
+    upsertAsync(obj: any | Array<any>): Promise<any>;
 }

--- a/data-model.js
+++ b/data-model.js
@@ -3205,7 +3205,13 @@ DataModel.prototype.upsertAsync = function(obj) {
         }
     })).then(function() {
         // finally do update
-        return self.save(items);
+        return self.save(items).then(function(results) {
+            // delete $state
+            items.forEach(function (item) {
+                delete item.$state;
+            });
+            return Array.isArray(obj) ? results : results[0];
+        });
     });
 }
 

--- a/data-model.js
+++ b/data-model.js
@@ -35,6 +35,8 @@ var {ZeroOrOneMultiplicityListener} = require('./zero-or-one-multiplicity');
 var {OnNestedQueryListener} = require('./OnNestedQueryListener');
 var {OnExecuteNestedQueryable} = require('./OnExecuteNestedQueryable');
 var {hasOwnProperty} = require('./has-own-property');
+require('@themost/promise-sequence');
+var DataObjectState = types.DataObjectState;
 /**
  * @this DataModel
  * @param {DataField} field
@@ -3145,9 +3147,68 @@ DataModel.prototype.getList = function() {
     });
     return d.promise;
 };
+/**
+ * @param obj {*|Array<*>}
+ * @param callback {Function}
+ * @returns {void|Promise<*>}
+ */
+DataModel.prototype.upsert = function(obj, callback) {
+    if (typeof callback === 'undefined') {
+        return this.upsertAsync(obj);
+    } else {
+        return this.upsertAsync(obj).then(function(result) {
+            return callback(null, result);
+        }).catch(function(err) {
+            return callback(err);
+        });
+    }
+};
+
+/**
+ * @param {*|Array<*>} obj
+ * @returns {Promise<*>}
+ */
+DataModel.prototype.upsertAsync = function(obj) {
+    var items = [];
+    var self = this;
+    // create a clone
+    var thisModel = this.clone(this.context);
+    // format object(s) to array
+    if (Array.isArray(obj)) {
+        items = obj;
+    } else {
+        items.push(obj);
+    }
+    return Promise.sequence(items.map(function(item) {
+        return function() {
+            if (thisModel.primaryKey == null) {
+                throw new DataError('E_PKEY', 'Primary key cannot be empty at this context', null, thisModel.name);
+            }
+            if (Object.prototype.hasOwnProperty.call(item, thisModel.primaryKey) === false) {
+                // do nothing DataMode.save() will try to find object state based on its attributes
+                return Promise.resolve(item);
+            } else if (item[thisModel.primaryKey] == null) {
+                // delete null primary key
+                delete item[thisModel.primaryKey];
+                // and continue
+                return Promise.resolve(item);
+            }
+            // try to find object by primary key
+            return thisModel.where(thisModel.primaryKey).equal(item[thisModel.primaryKey]).silent().count().then(function(result) {
+                // if object does not exist, set state to insert
+                Object.assign(item, {
+                    $state: (result === 0) ? DataObjectState.Insert : DataObjectState.Update
+                });
+                // and return item
+                return Promise.resolve(item);
+            });
+        }
+    })).then(function() {
+        // finally do update
+        return self.save(items);
+    });
+}
 
 module.exports = {
     DataModel
-}
-
-
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.40",
+  "version": "2.6.41",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.40",
+  "version": "2.6.41",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/spec/DataModel.upsert.spec.ts
+++ b/spec/DataModel.upsert.spec.ts
@@ -1,0 +1,93 @@
+import {TestApplication} from './TestApplication';
+import {DataContext} from '../index';
+import {resolve} from 'path';
+import {TestUtils} from './adapter/TestUtils';
+
+describe('DataModel.upsert', () => {
+    let app: TestApplication;
+    let context: DataContext;
+    beforeAll((done) => {
+        app = new TestApplication(resolve(__dirname, 'test2'));
+        // set default adapter
+        app.getConfiguration().setSourceAt('adapters', [
+            {
+                name: 'test-local',
+                invariantName: 'test',
+                default: true,
+                options: {
+                    database: resolve(__dirname, 'test2/db/local.db')
+                }
+            }
+        ])
+        context = app.createContext();
+        return done();
+    });
+    afterAll(async () => {
+        await context.finalize();
+        await app.finalize();
+    });
+    it('should use upsert() to insert or update a single item', async () => {
+        await TestUtils.executeInTransaction(context, async () => {
+            const AccessLevelTypes = context.model('AccessLevelType');
+            const item = {
+                "id": 350,
+                "name": "Review",
+                "alternateName": "review"
+            };
+            await expect(AccessLevelTypes.upsert(item)).rejects.toThrow('Access Denied');
+            Object.assign(context, {
+                user: {
+                    name: 'alexis.rees@example.com'
+                }
+            });
+            const result = await AccessLevelTypes.upsert(item);
+            expect(Array.isArray(result)).toBeFalsy();
+            const inserted = await AccessLevelTypes.where('id').equal(item.id).getItem();
+            expect(inserted).toBeTruthy();
+            expect(inserted.id).toEqual(item.id);
+            Object.assign(context, {
+                user: null
+            });
+        });
+    });
+
+    it('should use upsert() to insert or update multiple items', async () => {
+        await TestUtils.executeInTransaction(context, async () => {
+            const AccessLevelTypes = context.model('AccessLevelType');
+            const items = [
+                {
+                    "id": 350,
+                    "name": "Review",
+                    "alternateName": "review"
+                },
+                {
+                    "id": 360,
+                    "name": "Merge",
+                    "alternateName": "merge"
+                }
+            ];
+            await expect(AccessLevelTypes.upsert(items)).rejects.toThrow('Access Denied');
+            Object.assign(context, {
+                user: {
+                    name: 'alexis.rees@example.com'
+                }
+            });
+            const result = await AccessLevelTypes.upsert(items);
+            expect(Array.isArray(result)).toBeTruthy();
+            let inserted = await AccessLevelTypes.where('id').equal(350).getItem();
+            expect(inserted).toBeTruthy();
+            inserted = await AccessLevelTypes.where('id').equal(360).getItem();
+            expect(inserted).toBeTruthy();
+            // update
+            inserted.name = 'Review and merge';
+            await AccessLevelTypes.upsert(inserted);
+            inserted = await AccessLevelTypes.where('id').equal(360).getItem();
+            expect(inserted).toBeTruthy();
+            expect(inserted.name).toEqual('Review and merge');
+
+            Object.assign(context, {
+                user: null
+            });
+        });
+    });
+});

--- a/spec/test2/config/models/AccessLevelType.json
+++ b/spec/test2/config/models/AccessLevelType.json
@@ -24,7 +24,7 @@
             "account": "*"
         },
         {
-            "mask": 1,
+            "mask": 15,
             "type": "global",
             "account": "Administrators"
         },


### PR DESCRIPTION
This PR closes #71 by adding DataModel.upsert() method which validates the existence of an object before inserting or updating it.