### PR TITLE
Custom query expression

### DIFF
--- a/data-field-query-resolver.js
+++ b/data-field-query-resolver.js
@@ -1,0 +1,66 @@
+const {Args, DataError} = require('@themost/common');
+const {hasOwnProperty} = require('./has-own-property');
+const {DataAttributeResolver} = require('./data-attribute-resolver');
+
+class DataFieldQueryResolver {
+    /**
+     * @param {import("./data-model").DataModel} target
+     */
+    constructor(target) {
+        this.target = target;
+    }
+
+    /**
+     *
+     * @param {string} value
+     * @returns {string}
+     */
+    escapeName(value) {
+        if (/^\$/.test(value)) {
+            return value.replace(/(\$?(\w+)?)/g, '$2').replace(/\.(\w+)/g, '/$1')
+        }
+    }
+
+    /**
+     * @param {string} name
+     * @returns {{$select?: import("@themost/query").QueryField, $expand?: import("@themost/query").QueryEntity[]}|null}
+     */
+    resolve(name) {
+        const field = this.target.getAttribute(name);
+        Args.check(field != null, new DataError('E_FIELD','The specified field cannot be found', null, this.target.name, name));
+        if (field.query == null) {
+            return null;
+        }
+        /**
+         * @type {{$project: *, $lookup: *}}
+         */
+        var customQuery = field.query;
+        // try to find $project[x.name] property e.g. { orderEmail: "$customer.email" }
+        if (customQuery.$project && hasOwnProperty(customQuery.$project, field.name)) {
+            // get expr
+            const expr = Object.getOwnPropertyDescriptor(customQuery.$project, field.name).value;
+            if (typeof expr === 'string') {
+                // convert expression to an equivalent $select expression
+                // e.g. $customer.email -> customer/email
+                const selectAttribute = this.escapeName(expr);
+                // resolve nested attribute ($select and $expand expressions)
+                /**
+                 * @type {DataQueryable}
+                 */
+                const q = this.target.asQueryable();
+                const result = new DataAttributeResolver().resolveNestedAttribute.call(q, selectAttribute);
+                return {
+                    $select: result,
+                    $expand: q.query.$expand ? [].concat(q.query.$expand) : []
+                }
+            } else {
+                throw new Error('Resolving advanced expression is not yet implemented');
+            }
+        }
+    }
+
+}
+
+module.exports = {
+    DataFieldQueryResolver
+}

--- a/data-field-query-resolver.js
+++ b/data-field-query-resolver.js
@@ -79,7 +79,20 @@ class DataFieldQueryResolver {
                 if (typeof expr === 'string') {
                     select = new QueryField(this.formatName(expr)).as(name)
                 } else {
-                    throw new Error('Not yet implemented')
+                    const expr1 = Object.defineProperty({}, name, {
+                        configurable: true,
+                        enumerable: true,
+                        writable: true,
+                        value: expr
+                    });
+                    // Important note: Field references e.g. $customer.email
+                    // are not supported by @themost/query@Formatter
+                    // and should be replaced by name references e.g. { "$name": "customer.email" }
+                    // A workaround is being used here is a regular expression replacer which 
+                    // will try to replace  "$customer.email" with { "$name": "customer.email" }
+                    // but this operation is definitely a feature request for @themost/query
+                    const finalExpr = JSON.parse(JSON.stringify(expr1).replace(/"\$((\w+)(\.(\w+)){1,})"/g, '{ "$name": "$1" }'));
+                    select = Object.assign(new QueryField(), finalExpr);
                 }
             }
         }

--- a/data-field-query-resolver.js
+++ b/data-field-query-resolver.js
@@ -27,8 +27,11 @@ class DataFieldQueryResolver {
      */
     resolve(field) {
         Args.check(field != null, new DataError('E_FIELD','Field may not be null', null, this.target.name));
-        if (field.query == null) {
-            return null;
+        if (Array.isArray(field.query) === false) {
+            return {
+                select: null,
+                expand: []
+            };
         }
         let expand = [];
         let select = null;

--- a/model-schema.json
+++ b/model-schema.json
@@ -315,8 +315,47 @@
                             },
                             "validator": {
                                 "type": "string",
-                                "description": "A string which represetns the module path that exports a custom validator e.g. ./validators/custom-validator.js"
+                                "description": "A string which represents the module path that exports a custom validator e.g. ./validators/custom-validator.js"
                             }
+                        }
+                    },
+                    "query": {
+                        "type": "object",
+                        "description": "Defines a custom query expression to be used while selecting field.",
+                        "$lookup": {
+                            "type": "object",
+                            "properties": {
+                                "from": {
+                                    "type": "string"
+                                },
+                                "localField": {
+                                    "type": "string"
+                                },
+                                "foreignField": {
+                                    "type": "string"
+                                },
+                                "let": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                },
+                                "pipeline": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                },
+                                "as": {
+                                    "type": "string"
+                                }
+                            },
+                            "additionalProperties": true,
+                            "required": [
+                                "from"
+                            ],
+                            "description": "A query expression for joining other data models"
+                        },
+                        "$project": {
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "A query expression for selecting field"
                         }
                     }
                 },

--- a/spec/CustomQueryExpr.spec.ts
+++ b/spec/CustomQueryExpr.spec.ts
@@ -1,0 +1,102 @@
+import {TestUtils} from './adapter/TestUtils';
+import { TestApplication2 } from './TestApplication';
+import { DataContext } from '../types';
+import { DataConfigurationStrategy } from '../data-configuration';
+import { DataModelProperties } from '@themost/common';
+
+const TempOrderSchema = {
+    "name": "TempOrder",
+    "version": "3.0.0",
+    "fields": [
+        {
+            "@id": "https://themost.io/schemas/id",
+            "name": "id",
+            "title": "ID",
+            "description": "The identifier of the item.",
+            "type": "Counter",
+            "primary": true
+        },
+        {
+            "name": "acceptedOffer",
+            "title": "Accepted Offer",
+            "description": "The offer e.g. product included in the order.",
+            "type": "Offer"
+        },
+        {
+            "name": "customer",
+            "title": "Customer",
+            "description": "Party placing the order.",
+            "type": "Person",
+            "editable": false,
+            "nullable": false
+        },
+        {
+            "name": "orderDate",
+            "title": "Order Date",
+            "description": "Date order was placed.",
+            "type": "DateTime",
+            "value": "javascript:return new Date();"
+        },
+        {
+            "name": 'orderEmail',
+            "readonly": true,
+            "type": 'Text',
+            "nullable": true,
+            "query": {
+                "$project": {
+                    "orderEmail": '$customer.email'
+                }
+            }
+        },
+        {
+            "name": "orderedItem",
+            "title": "Ordered Item",
+            "description": "The item ordered.",
+            "type": "Product",
+            "expandable": true,
+            "editable": true,
+            "nullable": false
+        }
+    ],
+    "privileges": [
+        {
+            "mask": 15,
+            "type": "global"
+        },
+        {
+            "mask": 15,
+            "type": "global",
+            "account": "Administrators"
+        },
+        {
+            "mask": 1,
+            "type": "self",
+            "filter": "customer/user eq me()"
+        }
+    ]
+};
+
+describe('CustomQueryExpression', () => {
+
+    let app: TestApplication2;
+    let context: DataContext;
+
+    beforeAll(async () => {
+        app = new TestApplication2();
+        context = app.createContext();
+    });
+
+    afterAll(async () => {
+        await context.finalizeAsync();
+        await app.finalize();
+    });
+
+    it('should change model definition', async () => {
+        await TestUtils.executeInTransaction(context, async () => {
+            const configuration = app.getConfiguration().getStrategy(DataConfigurationStrategy);
+            configuration.setModelDefinition(TempOrderSchema);
+            await context.model('TempOrder').migrateAsync();
+        });
+    });
+    
+});

--- a/spec/CustomQueryExpr.spec.ts
+++ b/spec/CustomQueryExpr.spec.ts
@@ -2,7 +2,6 @@ import {TestUtils} from './adapter/TestUtils';
 import { TestApplication2 } from './TestApplication';
 import { DataContext } from '../types';
 import { DataConfigurationStrategy } from '../data-configuration';
-import { DataModelProperties } from '@themost/common';
 
 const TempOrderSchema = {
     "name": "TempOrder",
@@ -38,15 +37,54 @@ const TempOrderSchema = {
             "value": "javascript:return new Date();"
         },
         {
-            "name": 'orderEmail',
+            "name": "orderEmail",
             "readonly": true,
             "type": 'Text',
             "nullable": true,
-            "query": {
-                "$project": {
-                    "orderEmail": '$customer.email'
+            "query": [
+                {
+                    "$lookup": {
+                        "from": "PersonData",
+                        "foreignField": "id",
+                        "localField": "customer",
+                        "as": "customer"
+                    }
+                },
+                {
+                    "$project": {
+                        "orderEmail": "$customer.email"
+                    }
                 }
-            }
+            ]
+        },
+        {
+            "name": 'orderAddressLocality',
+            "readonly": true,
+            "type": 'Text',
+            "nullable": true,
+            "query": [
+                {
+                    "$lookup": {
+                        "from": "PersonData",
+                        "foreignField": "id",
+                        "localField": "customer",
+                        "as": "customer"
+                    }
+                },
+                {
+                    "$lookup": {
+                        "from": "PostalAddressData",
+                        "foreignField": "id",
+                        "localField": "$customer.address",
+                        "as": "address"
+                    }
+                },
+                {
+                    "$project": {
+                        "orderAddressLocality": "$address.addressLocality"
+                    }
+                }
+            ]
         },
         {
             "name": "orderedItem",
@@ -96,6 +134,25 @@ describe('CustomQueryExpression', () => {
             const configuration = app.getConfiguration().getStrategy(DataConfigurationStrategy);
             configuration.setModelDefinition(TempOrderSchema);
             await context.model('TempOrder').migrateAsync();
+            // insert a temporary object
+            const newOrder: any = {
+                orderDate: new Date(),
+                orderedItem: {
+                    name: 'Samsung Galaxy S4'
+                },
+                customer: {
+                    email: 'luis.nash@example.com'
+                }
+            };
+            await context.model('TempOrder').silent().save(newOrder);
+            const item = await context.model('TempOrder').where('id').equal(newOrder.id).silent().getItem();
+            expect(item).toBeTruthy();
+            expect(item.orderEmail).toEqual('luis.nash@example.com');
+            const orderAddressLocality = await context.model('Person')
+                .where('email').equal('luis.nash@example.com')
+                .select('address/addressLocality').silent().value();
+            expect(item.orderAddressLocality).toEqual(orderAddressLocality);
+
         });
     });
     

--- a/spec/CustomQueryExpr.spec.ts
+++ b/spec/CustomQueryExpr.spec.ts
@@ -44,7 +44,7 @@ const TempOrderSchema = {
             "query": [
                 {
                     "$lookup": {
-                        "from": "PersonData",
+                        "from": "Person",
                         "foreignField": "id",
                         "localField": "customer",
                         "as": "customer"
@@ -65,7 +65,7 @@ const TempOrderSchema = {
             "query": [
                 {
                     "$lookup": {
-                        "from": "PersonData",
+                        "from": "Person",
                         "foreignField": "id",
                         "localField": "customer",
                         "as": "customer"
@@ -73,7 +73,7 @@ const TempOrderSchema = {
                 },
                 {
                     "$lookup": {
-                        "from": "PostalAddressData",
+                        "from": "PostalAddress",
                         "foreignField": "id",
                         "localField": "$customer.address",
                         "as": "address"

--- a/spec/TestApplication.ts
+++ b/spec/TestApplication.ts
@@ -74,3 +74,17 @@ export class TestApplication extends IApplication {
     }
 
 }
+
+export class TestApplication2 extends TestApplication {
+    constructor() {
+        super(resolve(__dirname, 'test2'));
+        this.getConfiguration().getSourceAt('adapters').unshift({
+            name: 'test-local',
+            invariantName: 'test',
+            default: true,
+            options: {
+                database: resolve(__dirname, 'test2/db/local.db')
+            }
+        });
+    }
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -108,6 +108,28 @@ export declare class DataAssociationMapping implements DataAssociationMappingBas
     [k: string]: unknown;
 }
 
+
+
+export declare interface QueryPipelineLookup {
+    from: string;
+    localField?: string;
+    foreignField?: string;
+    let?: string;
+    pipeline?: {
+        $match: any;
+    }
+    as?: string
+}
+
+export declare interface QueryPipelineProject {
+    [name: string]: string | (1 | 0) | any;
+}
+
+export declare interface QueryPipelineItem {
+    $lookup?: QueryPipelineLookup;
+    $project?: QueryPipelineProject
+}
+
 export declare class DataField {
     name: string;
     property?: string;
@@ -131,7 +153,7 @@ export declare class DataField {
     multiplicity?: string;
     indexed?: boolean;
     size?: number;
-    query?: any;
+    query?: QueryPipelineItem[];
 }
 
 export declare class DataEventArgs {

--- a/types.d.ts
+++ b/types.d.ts
@@ -125,9 +125,9 @@ export declare interface QueryPipelineProject {
     [name: string]: string | (1 | 0) | any;
 }
 
-export declare interface QueryPipelineItem {
+export declare interface QueryPipelineStage {
     $lookup?: QueryPipelineLookup;
-    $project?: QueryPipelineProject
+    $project?: QueryPipelineProject;
 }
 
 export declare class DataField {
@@ -153,7 +153,7 @@ export declare class DataField {
     multiplicity?: string;
     indexed?: boolean;
     size?: number;
-    query?: QueryPipelineItem[];
+    query?: QueryPipelineStage[];
 }
 
 export declare class DataEventArgs {

--- a/types.d.ts
+++ b/types.d.ts
@@ -131,6 +131,7 @@ export declare class DataField {
     multiplicity?: string;
     indexed?: boolean;
     size?: number;
+    query?: any;
 }
 
 export declare class DataEventArgs {


### PR DESCRIPTION
This MR adds a new feature for defining custom query expressions for readonly fields. This operation allows parsing custom query expressions and include them in data model's view adapter.
e.g. A business process needs customer's email address `customer.email` to be an attribute of an `Order` even if it would be retrieved by expanding `customer`.

Define a readonly attribute `orderEmail`
```
{
    "name": "orderEmail",
    "readonly": true,
    "type": "Text",
    "nullable": true,
    "query": [
        {
            "$lookup": {
                "from": "Person",
                "foreignField": "id",
                "localField": "customer",
                "as": "customer"
            }
        },
        {
            "$project": {
                "orderEmail": "$customer.email"
            }
        }
    ]
}
```
where `orderEmail` has a custom query with two stages:
1. Join `Person` collection based on `customer` attribute of an order.
```
{
    "$lookup": {
        "from": "Person",
        "foreignField": "id",
        "localField": "customer",
        "as": "customer"
    }
}
```
3. Select `customer.email` as part of an order
```
{
    "$project": {
         "orderEmail": "$customer.email"
     }
}
```

The result will be a new extra field based on an SQL statement equivalent to the following one:
```
CREATE VIEW OrderData AS SELECT ..., OrderBase.customer , customer.email AS orderEmail 
     LEFT JOIN PersonData AS customer ON OrderBase.customer = customer.id
```


