### PR TITLE
Use insertable attribute

### DIFF
--- a/data-model.js
+++ b/data-model.js
@@ -437,6 +437,9 @@ function DataModel(obj) {
                     clone.cloned = true;
                 }
             }
+            if (clone.insertable === false && clone.editable === false && clone.model === self.name) {
+                clone.readonly = true;
+            }
             //finally push field
             attributes.push(clone);
         });
@@ -1416,6 +1419,11 @@ function cast_(obj, state) {
             description:exclude non editable attributes on update operation
              */
             return (state===2) ? (hasOwnProperty(y, 'editable') ? y.editable : true) : true;
+        }).filter(function(x) {
+            if (x.insertable === false && x.editable === false) {
+                return false;
+            }
+            return true;
         }).forEach(function(x) {
             name = hasOwnProperty(obj, x.property) ? x.property : x.name;
             if (hasOwnProperty(obj, name))

--- a/data-model.js
+++ b/data-model.js
@@ -419,9 +419,10 @@ function DataModel(obj) {
             if (typeof x.model === 'undefined')
                 x.model = self.name;
             var clone = x;
-            //if base model exists and current field is not primary key field
-            if (baseModel && !x.primary) {
-                //get base field
+            // if base model exists and current field is not primary key field
+            var isPrimary = !!x.primary;
+            if (baseModel != null && isPrimary === false) {
+                // get base field
                 field = baseModel.field(x.name);
                 if (field) {
                     //clone field
@@ -2221,6 +2222,17 @@ DataModel.prototype.migrate = function(callback)
     var context = self.context;
     //do migration
     var fields = self.attributes.filter(function(x) {
+        if (x.insertable === false && x.editable === false && x.model === self.name) {
+            if (typeof x.query === 'undefined') {
+                throw new DataError('E_MODEL', 'A non-insertable and non-editable field should have a custom query defined.', null, self.name, x.name);
+            }
+            // validate source and view
+            if (self.sourceAdapter === self.viewAdapter) {
+                throw new DataError('E_MODEL', 'A data model with the same source and view data object cannot have virtual columns.', null, self.name, x.name);
+            }
+            // exclude virtual column
+            return false;
+        }
         return (self.name === x.model) && (!x.many);
     });
 

--- a/model-schema.json
+++ b/model-schema.json
@@ -145,8 +145,13 @@
                         "type": "boolean",
                         "description": "A boolean which indicates whether this attribute is readonly or not. A readonly value must have a default value or a calculated value."
                     },
+                    "insertable": {
+                        "default": true,
+                        "type": "boolean",
+                        "description": "A boolean which indicates whether this attribute is insertable or not."
+                    },
                     "editable": {
-                        "default": false,
+                        "default": true,
                         "type": "boolean",
                         "description": "A boolean which indicates whether this attribute is editable or not."
                     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.8.3",
+      "version": "2.8.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/promise-sequence": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/spec/CustomQueryExpr.spec.ts
+++ b/spec/CustomQueryExpr.spec.ts
@@ -1,4 +1,5 @@
 import {TestUtils} from './adapter/TestUtils';
+import { TestAdapter } from './adapter/TestAdapter';
 import { TestApplication2 } from './TestApplication';
 import { DataContext } from '../types';
 import { DataConfigurationStrategy } from '../data-configuration';
@@ -303,6 +304,8 @@ const ExtendedProductSchema = {
             "name": "priceCategory",
             "type": "Text",
             "readonly": true,
+            "insertable": false,
+            "editable": false,
             "nullable": true,
             "query": [
                 {
@@ -440,7 +443,12 @@ describe('CustomQueryExpression', () => {
         await TestUtils.executeInTransaction(context, async () => {
             const configuration = app.getConfiguration().getStrategy(DataConfigurationStrategy);
             configuration.setModelDefinition(ExtendedProductSchema);
-            await context.model('ExtendedProduct').migrateAsync();
+            const ExtendedProducts = context.model('ExtendedProduct');
+            await ExtendedProducts.migrateAsync();
+            // validate non-insertable columns
+            const db: TestAdapter = context.db as TestAdapter;
+            const columns = await db.table(ExtendedProducts.sourceAdapter).columnsAsync();
+            expect(columns.find((item) => item.name === 'priceCategory')).toBeFalsy();
             // insert a temporary object
             const newProduct: any = {
                 name: 'Samsung Galaxy S4 XL',

--- a/spec/CustomQueryExpr.spec.ts
+++ b/spec/CustomQueryExpr.spec.ts
@@ -452,7 +452,8 @@ describe('CustomQueryExpression', () => {
             // insert a temporary object
             const newProduct: any = {
                 name: 'Samsung Galaxy S4 XL',
-                price: 560
+                price: 560,
+                priceCategory: 'Normal'
             };
             await context.model('ExtendedProduct').silent().save(newProduct);
             const item = await context.model('ExtendedProduct').where('id').equal(newProduct.id).silent().getItem();

--- a/types.d.ts
+++ b/types.d.ts
@@ -139,6 +139,7 @@ export declare class DataField {
     calculation?: string;
     readonly?: boolean;
     editable?: boolean;
+    insertable?: boolean;
     mapping?: DataAssociationMapping;
     expandable?: boolean;
     nested?: boolean;


### PR DESCRIPTION
This MR closes #94 and implements `DataField.insertable` for handling virtual columns that should be included only in view data objects.
e.g.
```
{
    "name": "ExtendedProduct",
    "version": "3.0.0",
    "inherits": "Product",
    "fields": [
        {
            "name": "priceCategory",
            "type": "Text",
            "readonly": true,
            "insertable": false,
            "editable": false,
            "nullable": true,
            "query": [
                {
                    "$project": {
                        "priceCategory": {
                            "$cond": [
                                {
                                    "$gt": [
                                        "$price",
                                        1000
                                    ]
                                },
                                'Expensive',
                                'Normal'
                            ]
                        }
                    }
                }
            ]
        }
    ],
    "privileges": [
        {
            "mask": 15,
            "type": "global"
        },
        {
            "mask": 15,
            "type": "global",
            "account": "Administrators"
        },
        {
            "mask": 1,
            "type": "self",
            "filter": "customer/user eq me()"
        }
    ]
}
```