### PR TITLE
create data filter parser

### DIFF
--- a/data-model-filter.parser.d.ts
+++ b/data-model-filter.parser.d.ts
@@ -1,0 +1,9 @@
+import { AsyncSeriesEventEmitter } from '@themost/events';
+import { DataModel } from './data-model';
+
+export declare class DataModelFilterParser {
+    constructor(model: DataModel);
+    resolvingMember: AsyncSeriesEventEmitter<{ target: DataModelFilterParser, member: string, result: { $select: any, $expand?: any } }>;
+    resolvingMethod: AsyncSeriesEventEmitter<{ target: DataModelFilterParser, method: string, args: any, result: any }>;
+    parseAsync(str: string): Promise<{ $where: any, $expand?: any }>;
+}

--- a/data-model-filter.parser.js
+++ b/data-model-filter.parser.js
@@ -94,7 +94,7 @@ class DataModelFilterParser {
         }
 
         parser.resolveMethod = function(name, args, cb) {
-            const thisModel = this.model;
+            const thisModel = self.model;
             const event = {
                 target: self,
                 method: name,

--- a/data-model-filter.parser.js
+++ b/data-model-filter.parser.js
@@ -1,0 +1,143 @@
+const { AsyncSeriesEventEmitter } = require('@themost/events');
+const { OpenDataParser } = require('@themost/query');
+const { DataAttributeResolver } = require('./data-attribute-resolver');
+const { DataFilterResolver } = require('./data-filter-resolver');
+
+class DataModelFilterParser {
+    /**
+     * 
+     * @param {import("./data-model").DataModel} model 
+     */
+    constructor(model) {
+        this.resolvingMember = new AsyncSeriesEventEmitter();
+        this.resolvingMethod = new AsyncSeriesEventEmitter();
+        this.model = model;
+    }
+    parse(str, callback) {
+        const self = this;
+        const thisModel = this.model;
+        const $expand = [];
+        const parser = new OpenDataParser();
+        parser.resolveMember = function(member, cb) {
+            const attr = thisModel.field(member);
+            if (attr) {
+                member = attr.name;
+                if (attr.multiplicity === 'ZeroOrOne') {
+                    var mapping1 = thisModel.inferMapping(member);
+                    if (mapping1 && mapping1.associationType === 'junction' && mapping1.parentModel === thisModel.name) {
+                        member = attr.name.concat('/', mapping1.childField);
+                    } else if (mapping1 && mapping1.associationType === 'junction' && mapping1.childModel === thisModel.name) {
+                        member = attr.name.concat('/', mapping1.parentField);
+                    }
+                }
+            }
+            const event = {
+                target: self,
+                member: member,
+                result: null
+            }
+            void self.resolvingMember.emit(event).then(() => {
+                if (event.result) {
+                    return cb(null, event.result.$select);
+                }
+                if (DataAttributeResolver.prototype.testNestedAttribute.call(thisModel,member)) {
+                    try {
+                        var member1 = member.split('/'),
+                            mapping = thisModel.inferMapping(member1[0]),
+                            expr;
+                        if (mapping && mapping.associationType === 'junction') {
+                            var expr1 = DataAttributeResolver.prototype.resolveJunctionAttributeJoin.call(thisModel, member);
+                            expr = {
+                                $expand: expr1.$expand
+                            };
+                            //replace member expression
+                            member = expr1.$select.$name.replace(/\./g,'/');
+                        }
+                        else {
+                            expr = DataAttributeResolver.prototype.resolveNestedAttributeJoin.call(thisModel, member);
+                            if (expr.$select) {
+                                member = expr.$select.$name.replace(/\./g,'/');
+                            }
+                        }
+                        if (expr && expr.$expand) {
+                            var arrExpr = [];
+                            if (Array.isArray(expr.$expand)) {
+                                arrExpr.push.apply(arrExpr, expr.$expand);
+                            } else {
+                                arrExpr.push(expr.$expand);
+                            }
+                            arrExpr.forEach(function(y) {
+                                var joinExpr = $expand.find(function(x) {
+                                    if (x.$entity && x.$entity.$as) {
+                                        return (x.$entity.$as === y.$entity.$as);
+                                    }
+                                    return false;
+                                });
+                                if (joinExpr == null)
+                                    $expand.push(y);
+                            });
+                        }
+                    }
+                    catch (err) {
+                        return cb(err);
+                    }
+                }
+                if (typeof thisModel.resolveMember === 'function') {
+                    thisModel.resolveMember.call(thisModel, member, cb);
+                } else {
+                    DataFilterResolver.prototype.resolveMember.call(thisModel, member, cb);
+                }
+            }).catch(function(err) {
+                return callback(err);
+            });
+            
+        }
+
+        parser.resolveMethod = function(name, args, cb) {
+            const thisModel = this.model;
+            const event = {
+                target: self,
+                method: name,
+                args: args,
+                result: null
+            }
+            void self.resolvingMethod.emit(event).then(function() {
+                if (event.result) {
+                    return cb(null, event.result);
+                }
+                if (typeof thisModel.resolveMethod === 'function') {
+                    thisModel.resolveMethod.call(thisModel, name, args, cb);
+                } else {
+                    DataFilterResolver.prototype.resolveMethod.call(thisModel, name, args, cb);
+                }
+            }).catch(function(err) {
+                return cb(err);
+            });
+        }
+
+        void parser.parse(str, function(err, result) {
+            if (err) {
+                return callback(err);
+            }
+            return callback(null, {
+                $where: result,
+                $expand: $expand
+            });
+        });
+    }
+    parseAsync(str) {
+        const self = this;
+        return new Promise(function(resolve, reject) {
+            void self.parse(str, function(err, result) {
+                if (err) {
+                    return reject(err);
+                }
+                return resolve(result);
+            });
+        });
+    }
+}
+
+module.exports = {
+    DataModelFilterParser
+}

--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -37,6 +37,7 @@ export declare class DataModel extends SequentialEventEmitter{
     search(text: string): DataQueryable;
     asQueryable(): DataQueryable;
     filter(params: any, callback?: (err?: Error, res?: any) => void): void;
+    filterAsync(params: any): Promise<any>;
     find(obj: any):DataQueryable;
     select(...attr: any[]): DataQueryable;
     orderBy(attr: any): DataQueryable;

--- a/data-model.js
+++ b/data-model.js
@@ -930,6 +930,10 @@ DataModel.prototype.filter = function(params, callback) {
     }
 };
 
+DataModel.prototype.filterAsync = function(params) {
+    return this.filter(params);
+};
+
 /**
  * Prepares a data query with the given object as parameters and returns the equivalent DataQueryable instance
  * @param {*} obj - An object which represents the query parameters

--- a/data-permission.d.ts
+++ b/data-permission.d.ts
@@ -1,7 +1,7 @@
 // MOST Web Framework 2.0 Codename Blueshift BSD-3-Clause license Copyright (c) 2017-2022, THEMOST LP All rights reserved
 import {DataModel} from "./data-model";
 import {DataQueryable} from "./data-queryable";
-import {BeforeExecuteEventListener, BeforeRemoveEventListener, BeforeSaveEventListener, DataEventArgs} from "./types";
+import {BeforeExecuteEventListener, BeforeRemoveEventListener, BeforeSaveEventListener, DataEventArgs, DataModelPrivilege} from "./types";
 
 export declare class DataPermissionEventArgs {
     model: DataModel;
@@ -33,4 +33,10 @@ export declare class DataPermissionEventListener implements BeforeSaveEventListe
     beforeExecute(event: DataEventArgs, callback: (err?: Error) => void): void;
 
     validate(event: DataEventArgs, callback: (err?: Error) => void): void;
+}
+
+export declare class DataPermissionExclusion {
+    constructor(model: any);
+    shouldExclude(privilege: DataModelPrivilege, callback: (err?: Error, res?: boolean) => void): void;
+    shouldExcludeAsync(privilege: DataModelPrivilege): Promise<boolean>;
 }

--- a/data-permission.js
+++ b/data-permission.js
@@ -118,17 +118,12 @@ DataPermissionExclusion.prototype.shouldExclude = function (privilege, callback)
     }
     var context = this.model.context;
     var users = context.model('User');
-    Object.assign(context, {
-        user: {
-            name: 'luis.nash@example.com',
-            authenticationScope: 'profile'
-        }
-    })
     var parser = new DataModelFilterParser(users);
+    var username = (context.user && context.user.name) || 'anonymous';
     var addSelect = [
         {
             name: {
-                $value: (context.user && context.user.name) || 'anonymous'
+                $value: username
             }
         }
     ];
@@ -162,7 +157,8 @@ DataPermissionExclusion.prototype.shouldExclude = function (privilege, callback)
             $expand: q.$expand,
             $where: q.$where
         });
-        void context.db.execute(q1.query, function (err, result) {
+        q1.query.prepare().where('name').equal(username);
+        void context.db.execute(q1.query, [], function (err, result) {
             if (err) {
                 return callback(err);
             }

--- a/data-permission.js
+++ b/data-permission.js
@@ -112,11 +112,12 @@ PermissionMask.Owner = 31;
 function splitScope(str) {
     // the default regular expression includes comma /([\x21\x23-\x5B\x5D-\x7E]+)/g
     // the modified regular expression excludes comma /x2C /([\x21\x23-\x2B\x2D-\x5B\x5D-\x7E]+)/g
-    const re = /([\x21\x23-\x2B\x2D-\x5B\x5D-\x7E]+)/g
-    let match;
-    const results = [];
-    while((match = re.exec(str)) !== null) {
+    var re = /([\x21\x23-\x2B\x2D-\x5B\x5D-\x7E]+)/g
+    var results = [];
+    var match = re.exec(str);
+    while(match !== null) {
         results.push(match[0]);
+        match = re.exec(str);
     }
     return results;
 }
@@ -763,8 +764,7 @@ DataPermissionEventListener.prototype.beforeExecute = function (event, callback)
     }
     //ensure silent query operation
     if (event.emitter && event.emitter.$silent) {
-        callback();
-        return;
+        return callback();
     }
     var model = event.model;
     /**
@@ -787,8 +787,7 @@ DataPermissionEventListener.prototype.beforeExecute = function (event, callback)
     }
     //do not check permissions if the target model has no privileges defined
     if (model.privileges.filter(function (x) { return !x.disabled; }, model.privileges).length === 0) {
-        callback(null);
-        return;
+        return callback(null);
     }
     //infer permission mask
     if (typeof event.mask !== 'undefined') {
@@ -1045,7 +1044,7 @@ DataPermissionEventListener.prototype.beforeExecute = function (event, callback)
 
     }
     else {
-        callback();
+        return callback();
     }
 };
 

--- a/data-permission.js
+++ b/data-permission.js
@@ -2,15 +2,17 @@
 /*eslint no-var: "off"*/
 // noinspection ES6ConvertVarToLetConst
 
-var {QueryEntity} = require('@themost/query');
-var {QueryUtils} = require('@themost/query');
+var { QueryEntity } = require('@themost/query');
+var { QueryUtils } = require('@themost/query');
 var async = require('async');
-var {AccessDeniedError} = require('@themost/common');
-var {DataConfigurationStrategy} = require('./data-configuration');
+var { AccessDeniedError } = require('@themost/common');
+var { DataConfigurationStrategy } = require('./data-configuration');
 var _ = require('lodash');
-var {DataCacheStrategy} = require('./data-cache');
+var { DataCacheStrategy } = require('./data-cache');
 var Q = require('q');
-var {hasOwnProperty} = require('./has-own-property');
+var { hasOwnProperty } = require('./has-own-property');
+var { at } = require('lodash');
+var { DataModelFilterParser } = require('./data-model-filter.parser');
 
 /**
  * @class
@@ -96,6 +98,95 @@ PermissionMask.Execute = 16;
  * @type {number}
  */
 PermissionMask.Owner = 31;
+/**
+ * 
+ * @param {import("./data-model").DataModel} model 
+ */
+function DataPermissionExclusion(model) {
+    this.model = model;
+}
+/**
+ * @param {import("./types").DataModelPrivilege} privilege 
+ * @param {function(Error=,boolean=)} callback
+ */
+DataPermissionExclusion.prototype.shouldExclude = function (privilege, callback) {
+    if (privilege == null) {
+        return callback(new Error('Data model privilege may not be null'));
+    }
+    if (privilege.exclude == null) {
+        return callback();
+    }
+    var context = this.model.context;
+    var users = context.model('User');
+    Object.assign(context, {
+        user: {
+            name: 'luis.nash@example.com',
+            authenticationScope: 'profile'
+        }
+    })
+    var parser = new DataModelFilterParser(users);
+    var addSelect = [
+        {
+            name: {
+                $value: (context.user && context.user.name) || 'anonymous'
+            }
+        }
+    ];
+    parser.resolvingMember.subscribe(function (event) {
+        var propertyPath = event.member.split('/');
+        if (propertyPath[0] === 'context') {
+            propertyPath.splice(0, 1);
+            var property = at(context, propertyPath.join('.'))[0];
+            var propertyName = propertyPath[propertyPath.length - 1];
+            var exists = addSelect.findIndex((item) => Object.prototype.hasOwnProperty.call(item, propertyPath));
+            if (exists < 0) {
+                var select = {};
+                Object.defineProperty(select, propertyName, {
+                    enumerable: true,
+                    configurable: true,
+                    value: {
+                        $value: property
+                    }
+                });
+                addSelect.push(select);
+            }
+            event.result = {
+                $select: propertyName
+            }
+        }
+    });
+    void parser.parseAsync(privilege.exclude).then(function (q) {
+        var q1 = users.asQueryable();
+        q1.query.select([].concat(addSelect));
+        Object.assign(q1.query, {
+            $expand: q.$expand,
+            $where: q.$where
+        });
+        void context.db.execute(q1.query, function (err, result) {
+            if (err) {
+                return callback(err);
+            }
+            return callback(null, result.length > 0);
+        });
+    }).catch(function (err) {
+        return callback(err);
+    });
+};
+/**
+ * @param {import("./types").DataModelPrivilege} privilege 
+ * @param {function(Error=,boolean=)} callback
+ */
+DataPermissionExclusion.prototype.shouldExcludeAsync = function (privilege) {
+    var self = this;
+    return new Promise(function(resolve, reject) {
+        void self.shouldExclude(privilege, function(err, result) {
+            if (err) {
+                return reject(err);
+            }
+            return resolve(result);
+        });
+    });
+};
 
 /**
  * @class
@@ -109,8 +200,7 @@ function DataPermissionEventListener() {
  * @param {DataEventArgs} event - An object that represents the event arguments passed to this operation.
  * @param {Function} callback - A callback function that should be called at the end of this operation. The first argument may be an error if any occurred.
  */
-DataPermissionEventListener.prototype.beforeSave = function(event, callback)
-{
+DataPermissionEventListener.prototype.beforeSave = function (event, callback) {
     DataPermissionEventListener.prototype.validate(event, callback);
 };
 /**
@@ -119,8 +209,7 @@ DataPermissionEventListener.prototype.beforeSave = function(event, callback)
  * @param {Function} callback - A callback function that should be called at the end of this operation. The first argument may be an error if any occurred.
  * @returns {DataEventListener}
  */
-DataPermissionEventListener.prototype.beforeRemove = function(event, callback)
-{
+DataPermissionEventListener.prototype.beforeRemove = function (event, callback) {
     DataPermissionEventListener.prototype.validate(event, callback);
 };
 /**
@@ -128,7 +217,7 @@ DataPermissionEventListener.prototype.beforeRemove = function(event, callback)
  * @param {DataEventArgs|DataPermissionEventArgs} event - An object that represents the event arguments passed to this operation.
  * @param {Function} callback - A callback function that should be called at the end of this operation. The first argument may be an error if any occurred.
  */
-DataPermissionEventListener.prototype.validate = function(event, callback) {
+DataPermissionEventListener.prototype.validate = function (event, callback) {
     var model = event.model;
     /**
      * @type {DataContext|*}
@@ -169,16 +258,14 @@ DataPermissionEventListener.prototype.validate = function(event, callback) {
     //validate throwError
     if (typeof event.throwError === 'undefined')
         event.throwError = true;
-    context.user = context.user || { name:'anonymous',authenticationType:'None' };
+    context.user = context.user || { name: 'anonymous', authenticationType: 'None' };
     //description: Use unattended execution account as an escape permission check account
     var authSettings = context.getConfiguration().getStrategy(DataConfigurationStrategy).getAuthSettings();
-    if (authSettings)
-    {
-        var unattendedExecutionAccount=authSettings.unattendedExecutionAccount;
+    if (authSettings) {
+        var unattendedExecutionAccount = authSettings.unattendedExecutionAccount;
         if ((typeof unattendedExecutionAccount !== 'undefined'
             || unattendedExecutionAccount != null)
-            && (unattendedExecutionAccount===context.user.name))
-        {
+            && (unattendedExecutionAccount === context.user.name)) {
             event.result = true;
             return callback();
         }
@@ -194,14 +281,14 @@ DataPermissionEventListener.prototype.validate = function(event, callback) {
         //do nothing
         return callback();
     }
-    effectiveAccounts(context, function(err, accounts) {
-        if (err) { 
+    effectiveAccounts(context, function (err, accounts) {
+        if (err) {
             return callback(err);
         }
-        var permEnabled = model.privileges.filter(function(x) { return !x.disabled; }, model.privileges).length>0;
+        var permEnabled = model.privileges.filter(function (x) { return !x.disabled; }, model.privileges).length > 0;
         //get all enabled privileges
-        var privileges = model.privileges.filter(function(x) { return !x.disabled && ((x.mask & requestMask) === requestMask) });
-        if (privileges.length===0) {
+        var privileges = model.privileges.filter(function (x) { return !x.disabled && ((x.mask & requestMask) === requestMask) });
+        if (privileges.length === 0) {
             if (event.throwError) {
                 //if the target model has privileges but it has no privileges with the requested mask
                 if (permEnabled) {
@@ -226,23 +313,23 @@ DataPermissionEventListener.prototype.validate = function(event, callback) {
             var cancel = false;
             event.result = false;
             //enumerate privileges
-            async.eachSeries(privileges, function(item, cb) {
+            async.eachSeries(privileges, function (item, cb) {
                 if (cancel) {
                     return cb();
                 }
                 //global
-                if (item.type==='global') {
+                if (item.type === 'global') {
                     if (typeof item.account !== 'undefined') {
                         //check if a privilege is assigned by the model
-                        if (item.account==='*') {
+                        if (item.account === '*') {
                             //get permission and exit
-                            cancel=true;
+                            cancel = true;
                             event.result = true;
                             return cb();
                         }
                         else if (hasOwnProperty(item, 'account')) {
-                            if (accounts.findIndex(function(x) { return x.name === item.account })>=0) {
-                                cancel=true;
+                            if (accounts.findIndex(function (x) { return x.name === item.account }) >= 0) {
+                                cancel = true;
                                 event.result = true;
                                 return cb();
                             }
@@ -253,21 +340,21 @@ DataPermissionEventListener.prototype.validate = function(event, callback) {
                         .and('parentPrivilege').equal(null)
                         .and('target').equal('0')
                         .and('workspace').equal(workspace)
-                        .and('account').in(accounts.map(function(x) { return x.id; }))
-                        .and('mask').bit(requestMask, requestMask).silent().count(function(err, count) {
+                        .and('account').in(accounts.map(function (x) { return x.id; }))
+                        .and('mask').bit(requestMask, requestMask).silent().count(function (err, count) {
                             if (err) {
                                 return cb(err);
                             }
                             else {
-                                if (count>=1) {
-                                    cancel=true;
+                                if (count >= 1) {
+                                    cancel = true;
                                     event.result = true;
                                 }
                                 return cb();
                             }
                         });
                 }
-                else if (item.type==='parent') {
+                else if (item.type === 'parent') {
                     var mapping = model.inferMapping(item.property);
                     if (!mapping) {
                         return cb();
@@ -281,19 +368,19 @@ DataPermissionEventListener.prototype.validate = function(event, callback) {
                     if (event.parentPrivilege) {
                         parentPrivilege = event.parentPrivilege;
                     }
-                    if (requestMask===PermissionMask.Create) {
+                    if (requestMask === PermissionMask.Create) {
                         permissions.where('privilege').equal(privilege)
                             .and('parentPrivilege').equal(parentPrivilege)
                             .and('target').equal(event.target[mapping.childField])
                             .and('workspace').equal(workspace)
-                            .and('account').in(accounts.map(function(x) { return x.id; }))
-                            .and('mask').bit(requestMask, requestMask).silent().count(function(err, count) {
+                            .and('account').in(accounts.map(function (x) { return x.id; }))
+                            .and('mask').bit(requestMask, requestMask).silent().count(function (err, count) {
                                 if (err) {
                                     return cb(err);
                                 }
                                 else {
-                                    if (count>=1) {
-                                        cancel=true;
+                                    if (count >= 1) {
+                                        cancel = true;
                                         event.result = true;
                                     }
                                     return cb();
@@ -302,7 +389,7 @@ DataPermissionEventListener.prototype.validate = function(event, callback) {
                     }
                     else {
                         //get original value
-                        model.where(model.primaryKey).equal(event.target[model.primaryKey]).select(mapping.childField).first(function(err, result) {
+                        model.where(model.primaryKey).equal(event.target[model.primaryKey]).select(mapping.childField).first(function (err, result) {
                             if (err) {
                                 cb(err);
                             }
@@ -311,14 +398,14 @@ DataPermissionEventListener.prototype.validate = function(event, callback) {
                                     .and('parentPrivilege').equal(parentPrivilege)
                                     .and('target').equal(result[mapping.childField])
                                     .and('workspace').equal(workspace)
-                                    .and('account').in(accounts.map(function(x) { return x.id; }))
-                                    .and('mask').bit(requestMask, requestMask).silent().count(function(err, count) {
+                                    .and('account').in(accounts.map(function (x) { return x.id; }))
+                                    .and('mask').bit(requestMask, requestMask).silent().count(function (err, count) {
                                         if (err) {
                                             return cb(err);
                                         }
                                         else {
-                                            if (count>=1) {
-                                                cancel=true;
+                                            if (count >= 1) {
+                                                cancel = true;
                                                 event.result = true;
                                             }
                                             return cb();
@@ -331,9 +418,9 @@ DataPermissionEventListener.prototype.validate = function(event, callback) {
                         });
                     }
                 }
-                else if (item.type==='item') {
+                else if (item.type === 'item') {
                     //if target object is a new object
-                    if (requestMask===PermissionMask.Create) {
+                    if (requestMask === PermissionMask.Create) {
                         //do nothing
                         return cb();
                     }
@@ -341,44 +428,43 @@ DataPermissionEventListener.prototype.validate = function(event, callback) {
                         .and('parentPrivilege').equal(null)
                         .and('target').equal(event.target[model.primaryKey])
                         .and('workspace').equal(workspace)
-                        .and('account').in(accounts.map(function(x) { return x.id; }))
-                        .and('mask').bit(requestMask, requestMask).silent().count(function(err, count) {
+                        .and('account').in(accounts.map(function (x) { return x.id; }))
+                        .and('mask').bit(requestMask, requestMask).silent().count(function (err, count) {
                             if (err) {
                                 return cb(err);
                             }
                             else {
-                                if (count>=1) {
-                                    cancel=true;
+                                if (count >= 1) {
+                                    cancel = true;
                                     event.result = true;
                                 }
                                 return cb();
                             }
                         });
                 }
-                else if (item.type==='self') {
+                else if (item.type === 'self') {
                     // check if the specified privilege has account attribute
                     if (typeof item.account !== 'undefined' && item.account !== null && item.account !== '*') {
                         // if user does not have this account return
-                        if (accounts.findIndex(function(x) { return x.name === item.account; }) < 0) {
+                        if (accounts.findIndex(function (x) { return x.name === item.account; }) < 0) {
                             return cb();
                         }
                     }
-                    if (requestMask===PermissionMask.Create) {
+                    if (requestMask === PermissionMask.Create) {
                         var query = QueryUtils.query(model.viewAdapter);
-                        var fields=[], field;
+                        var fields = [], field;
                         //cast target
                         var name, obj = event.target;
-                        model.attributes.forEach(function(x) {
+                        model.attributes.forEach(function (x) {
                             name = hasOwnProperty(obj, x.property) ? x.property : x.name;
-                            if (hasOwnProperty(obj, name))
-                            {
+                            if (hasOwnProperty(obj, name)) {
                                 var mapping = model.inferMapping(name);
                                 if (_.isNil(mapping)) {
                                     field = {};
                                     field[x.name] = { $value: obj[name] };
                                     fields.push(field);
                                 }
-                                else if ((mapping.associationType==='association') && (mapping.childModel===model.name)) {
+                                else if ((mapping.associationType === 'association') && (mapping.childModel === model.name)) {
                                     if (typeof obj[name] === 'object' && obj[name] !== null) {
                                         //set associated key value (event.g. primary key value)
                                         field = {};
@@ -398,7 +484,7 @@ DataPermissionEventListener.prototype.validate = function(event, callback) {
                         query.select(fields);
                         //set fixed query
                         query.$fixed = true;
-                        model.filter(item.filter, function(err, q) {
+                        model.filter(item.filter, function (err, q) {
                             if (err) {
                                 cb(err);
                             }
@@ -406,13 +492,13 @@ DataPermissionEventListener.prototype.validate = function(event, callback) {
                                 //set where from DataQueryable.query
                                 query.$where = q.query.$prepared;
                                 query.$expand = q.query.$expand;
-                                model.context.db.execute(query,null, function(err, result) {
+                                model.context.db.execute(query, null, function (err, result) {
                                     if (err) {
                                         return cb(err);
                                     }
                                     else {
-                                        if (result.length===1) {
-                                            cancel=true;
+                                        if (result.length === 1) {
+                                            cancel = true;
                                             event.result = true;
                                         }
                                         return cb();
@@ -423,16 +509,16 @@ DataPermissionEventListener.prototype.validate = function(event, callback) {
                     }
                     else {
                         //get privilege filter
-                        model.filter(item.filter, function(err, q) {
+                        model.filter(item.filter, function (err, q) {
                             if (err) {
                                 return cb(err);
                             }
                             else {
                                 //prepare query and append primary key expression
-                                q.where(model.primaryKey).equal(event.target[model.primaryKey]).silent().count(function(err, count) {
+                                q.where(model.primaryKey).equal(event.target[model.primaryKey]).silent().count(function (err, count) {
                                     if (err) { cb(err); return; }
-                                    if (count>=1) {
-                                        cancel=true;
+                                    if (count >= 1) {
+                                        cancel = true;
                                         event.result = true;
                                     }
                                     return cb();
@@ -446,7 +532,7 @@ DataPermissionEventListener.prototype.validate = function(event, callback) {
                     return cb();
                 }
 
-            }, function(err) {
+            }, function (err) {
                 if (err) {
                     return callback(err);
                 }
@@ -476,12 +562,12 @@ var ANONYMOUS_USER_CACHE_PATH = '/User/anonymous';
  * @private
  */
 function anonymousUser(context, callback) {
-    queryUser(context, 'anonymous', function(err, result) {
+    queryUser(context, 'anonymous', function (err, result) {
         if (err) {
             callback(err);
         }
         else {
-            callback(null, result || { id:null, name:'anonymous', groups:[], enabled:false});
+            callback(null, result || { id: null, name: 'anonymous', groups: [], enabled: false });
         }
     });
 }
@@ -501,9 +587,9 @@ function queryUser(context, username, callback) {
         if (_.isNil(users)) {
             return callback();
         }
-        users.where('name').equal(username).silent().select('id','name').expand('groups').getTypedItem().then(function(result) {
+        users.where('name').equal(username).silent().select('id', 'name').expand('groups').getTypedItem().then(function (result) {
             return callback(null, result);
-        }).catch(function(err) {
+        }).catch(function (err) {
             return callback(err);
         });
     }
@@ -519,7 +605,7 @@ function queryUser(context, username, callback) {
 function effectiveAccounts(context, callback) {
     if (_.isNil(context)) {
         //push no account
-        return callback(null, [ { id: null } ]);
+        return callback(null, [{ id: null }]);
     }
 
     /**
@@ -532,21 +618,21 @@ function effectiveAccounts(context, callback) {
      * @name DataContext#user
      * @memberof DataContext
      */
-    context.user = context.user || { name:'anonymous',authenticationType:'None' };
+    context.user = context.user || { name: 'anonymous', authenticationType: 'None' };
     context.user.name = context.user.name || 'anonymous';
     //if the current user is anonymous
     if (context.user.name === 'anonymous') {
         //get anonymous user data
-        cache.getOrDefault(ANONYMOUS_USER_CACHE_PATH, function() {
+        cache.getOrDefault(ANONYMOUS_USER_CACHE_PATH, function () {
             return Q.nfbind(anonymousUser)(context);
-        }).then(function(result) {
+        }).then(function (result) {
             var arr = [];
             if (result) {
                 arr.push({ 'id': result.id, 'name': result.name });
                 result.groups = result.groups || [];
-                result.groups.forEach(function(x) { arr.push({ 'id': x.id, 'name': x.name }); });
+                result.groups.forEach(function (x) { arr.push({ 'id': x.id, 'name': x.name }); });
             }
-            if (arr.length===0)
+            if (arr.length === 0)
                 arr.push({ id: null });
             return callback(null, arr);
         }).catch(function (err) {
@@ -557,24 +643,24 @@ function effectiveAccounts(context, callback) {
         //try to get data from cache
         var USER_CACHE_PATH = '/User/' + context.user.name;
 
-        cache.getOrDefault(USER_CACHE_PATH, function() {
+        cache.getOrDefault(USER_CACHE_PATH, function () {
             return Q.nfbind(queryUser)(context, context.user.name);
-        }).then(function(user) {
-            return cache.getOrDefault(ANONYMOUS_USER_CACHE_PATH, function() {
+        }).then(function (user) {
+            return cache.getOrDefault(ANONYMOUS_USER_CACHE_PATH, function () {
                 return Q.nfbind(anonymousUser)(context);
-            }).then(function(anonymous) {
-                var arr = [ ];
+            }).then(function (anonymous) {
+                var arr = [];
                 if (user) {
                     arr.push({ 'id': user.id, 'name': user.name });
                     if (_.isArray(user.groups))
-                        user.groups.forEach(function(x) { arr.push({ 'id': x.id, 'name': x.name }); });
+                        user.groups.forEach(function (x) { arr.push({ 'id': x.id, 'name': x.name }); });
                 }
                 if (anonymous) {
                     arr.push({ 'id': anonymous.id, 'name': 'anonymous' });
                     if (_.isArray(anonymous.groups))
-                        anonymous.groups.forEach(function(x) { arr.push({ 'id': x.id, 'name': x.name }); });
+                        anonymous.groups.forEach(function (x) { arr.push({ 'id': x.id, 'name': x.name }); });
                 }
-                if (arr.length===0)
+                if (arr.length === 0)
                     arr.push({ id: null });
                 return callback(null, arr);
             });
@@ -589,8 +675,7 @@ function effectiveAccounts(context, callback) {
  * @param {DataEventArgs} event - An object that represents the event arguments passed to this operation.
  * @param {Function} callback - A callback function that should be called at the end of this operation. The first argument may be an error if any occurred.
  */
-DataPermissionEventListener.prototype.beforeExecute = function(event, callback)
-{
+DataPermissionEventListener.prototype.beforeExecute = function (event, callback) {
     if (_.isNil(event.model)) {
         return callback();
     }
@@ -619,7 +704,7 @@ DataPermissionEventListener.prototype.beforeExecute = function(event, callback)
         parentPrivilege = model.name;
     }
     //do not check permissions if the target model has no privileges defined
-    if (model.privileges.filter(function(x) { return !x.disabled; }, model.privileges).length===0) {
+    if (model.privileges.filter(function (x) { return !x.disabled; }, model.privileges).length === 0) {
         callback(null);
         return;
     }
@@ -631,31 +716,29 @@ DataPermissionEventListener.prototype.beforeExecute = function(event, callback)
         if (event.query) {
             //infer mask from query type
             if (event.query.$select)
-            //read permissions
-                requestMask=1;
+                //read permissions
+                requestMask = 1;
             else if (event.query.$insert)
-            //create permissions
-                requestMask=2;
+                //create permissions
+                requestMask = 2;
             else if (event.query.$update)
-            //update permissions
-                requestMask=4;
+                //update permissions
+                requestMask = 4;
             else if (event.query.$delete)
-            //delete permissions
-                requestMask=8;
+                //delete permissions
+                requestMask = 8;
         }
     }
     //ensure context user
-    context.user = context.user || { name:'anonymous',authenticationType:'None' };
+    context.user = context.user || { name: 'anonymous', authenticationType: 'None' };
     //change: 2-May 2015
     //description: Use unattended execution account as an escape permission check account
     var authSettings = context.getConfiguration().getStrategy(DataConfigurationStrategy).getAuthSettings();
-    if (authSettings)
-    {
-        var unattendedExecutionAccount=authSettings.unattendedExecutionAccount;
+    if (authSettings) {
+        var unattendedExecutionAccount = authSettings.unattendedExecutionAccount;
         if ((typeof unattendedExecutionAccount !== 'undefined'
             || unattendedExecutionAccount !== null)
-            && (unattendedExecutionAccount===context.user.name))
-        {
+            && (unattendedExecutionAccount === context.user.name)) {
             return callback();
         }
     }
@@ -704,24 +787,24 @@ DataPermissionEventListener.prototype.beforeExecute = function(event, callback)
             }
         }
         //if model has no privileges defined
-        if (modelPrivileges.length===0) {
+        if (modelPrivileges.length === 0) {
             //do nothing and exit
             return callback();
         }
         //tuning up operation
         //validate request mask permissions against all users privilege { mask:<requestMask>,disabled:false,account:"*" }
-        var allUsersPrivilege = modelPrivileges.find(function(x) {
-            return (((x.mask & requestMask)===requestMask) && !x.disabled && (x.account==='*'));
+        var allUsersPrivilege = modelPrivileges.find(function (x) {
+            return (((x.mask & requestMask) === requestMask) && !x.disabled && (x.account === '*'));
         });
         if (typeof allUsersPrivilege !== 'undefined') {
             //do nothing
             return callback();
         }
 
-        effectiveAccounts(context, function(err, accounts) {
+        effectiveAccounts(context, function (err, accounts) {
             if (err) { callback(err); return; }
             //get all enabled privileges
-            var privileges = modelPrivileges.filter(function(x) {
+            var privileges = modelPrivileges.filter(function (x) {
                 return !x.disabled && ((x.mask & requestMask) === requestMask);
             });
 
@@ -729,21 +812,21 @@ DataPermissionEventListener.prototype.beforeExecute = function(event, callback)
             event.query.$lastIndex = parseInt(event.query.$lastIndex, 10) || 0;
             var cancel = false, assigned = false, entity = new QueryEntity(model.viewAdapter), expand = null,
                 perms1 = new QueryEntity(permissions.viewAdapter).as(permissions.viewAdapter + event.query.$lastIndex.toString()), expr = null;
-            async.eachSeries(privileges, function(item, cb) {
+            async.eachSeries(privileges, function (item, cb) {
                 if (cancel) {
                     return cb();
                 }
                 try {
-                    if (item.type==='global') {
+                    if (item.type === 'global') {
                         //check if a privilege is assigned by the model
-                        if (item.account==='*') {
+                        if (item.account === '*') {
                             //get permission and exit
-                            assigned=true;
+                            assigned = true;
                             return cb(new EachSeriesCancelled());
                         }
                         else if (hasOwnProperty(item, 'account')) {
-                            if (accounts.findIndex(function(x) { return x.name === item.account })>=0) {
-                                assigned=true;
+                            if (accounts.findIndex(function (x) { return x.name === item.account }) >= 0) {
+                                assigned = true;
                                 return cb(new EachSeriesCancelled());
                             }
                         }
@@ -752,21 +835,21 @@ DataPermissionEventListener.prototype.beforeExecute = function(event, callback)
                             and('parentPrivilege').equal(parentPrivilege).
                             and('target').equal('0').
                             and('workspace').equal(1).
-                            and('account').in(accounts.map(function(x) { return x.id; })).
-                            and('mask').bit(requestMask, requestMask).silent().count(function(err, count) {
+                            and('account').in(accounts.map(function (x) { return x.id; })).
+                            and('mask').bit(requestMask, requestMask).silent().count(function (err, count) {
                                 if (err) {
                                     cb(err);
                                 }
                                 else {
-                                    if (count>=1) {
-                                        assigned=true;
+                                    if (count >= 1) {
+                                        assigned = true;
                                         return cb(new EachSeriesCancelled());
                                     }
                                     cb();
                                 }
                             });
                     }
-                    else if (item.type==='parent') {
+                    else if (item.type === 'parent') {
                         //get field mapping
                         var mapping = model.inferMapping(item.property);
                         if (!mapping) {
@@ -778,12 +861,12 @@ DataPermissionEventListener.prototype.beforeExecute = function(event, callback)
                             and(perms1.select('privilege')).equal(mapping.childModel).
                             and(perms1.select('parentPrivilege')).equal(mapping.parentModel).
                             and(perms1.select('workspace')).equal(workspace).
-                            and(perms1.select('mask')).bit(requestMask,requestMask).
-                            and(perms1.select('account')).in(accounts.map(function(x) { return x.id; })).prepare(true);
-                        assigned=true;
+                            and(perms1.select('mask')).bit(requestMask, requestMask).
+                            and(perms1.select('account')).in(accounts.map(function (x) { return x.id; })).prepare(true);
+                        assigned = true;
                         cb();
                     }
-                    else if (item.type==='item') {
+                    else if (item.type === 'item') {
                         if (_.isNil(expr))
                             expr = QueryUtils.query();
                         expr.where(entity.select(model.primaryKey)).equal(perms1.select('target')).
@@ -791,20 +874,20 @@ DataPermissionEventListener.prototype.beforeExecute = function(event, callback)
                             and(perms1.select('parentPrivilege')).equal(null).
                             and(perms1.select('workspace')).equal(workspace).
                             and(perms1.select('mask')).bit(requestMask, requestMask).
-                            and(perms1.select('account')).in(accounts.map(function(x) { return x.id; })).prepare(true);
-                        assigned=true;
+                            and(perms1.select('account')).in(accounts.map(function (x) { return x.id; })).prepare(true);
+                        assigned = true;
                         cb();
                     }
-                    else if (item.type==='self') {
+                    else if (item.type === 'self') {
                         // check if the specified privilege has account attribute
                         if (typeof item.account !== 'undefined' && item.account !== null && item.account !== '*') {
                             // if user does not have this account return
-                            if (accounts.findIndex(function(x) { return x.name === item.account; }) < 0) {
+                            if (accounts.findIndex(function (x) { return x.name === item.account; }) < 0) {
                                 return cb();
                             }
                         }
-                        if (typeof item.filter === 'string' ) {
-                            model.filter(item.filter, function(err, q) {
+                        if (typeof item.filter === 'string') {
+                            model.filter(item.filter, function (err, q) {
                                 if (err) {
                                     cb(err);
                                 }
@@ -813,13 +896,13 @@ DataPermissionEventListener.prototype.beforeExecute = function(event, callback)
                                         if (_.isNil(expr))
                                             expr = QueryUtils.query();
                                         expr.$where = q.query.$prepared;
-                                        if (q.query.$expand) { 
+                                        if (q.query.$expand) {
                                             // combine expands
                                             expand = expand || [];
                                             expand.push.apply(expand, q.query.$expand);
                                         }
                                         expr.prepare(true);
-                                        assigned=true;
+                                        assigned = true;
                                         cb();
                                     }
                                     else
@@ -838,7 +921,7 @@ DataPermissionEventListener.prototype.beforeExecute = function(event, callback)
                 catch (e) {
                     cb(e);
                 }
-            }, function(err) {
+            }, function (err) {
                 if (err) {
                     cancel = (err instanceof EachSeriesCancelled);
                     if (!cancel) {
@@ -853,12 +936,12 @@ DataPermissionEventListener.prototype.beforeExecute = function(event, callback)
                     return callback();
                 }
                 else if (expr) {
-                    return context.model('Permission').migrate(function(err) {
+                    return context.model('Permission').migrate(function (err) {
                         if (err) { return callback(err); }
                         var q = QueryUtils.query(model.viewAdapter).select([model.primaryKey]).distinct();
                         if (expand) {
-                            var arrExpand=[].concat(expand);
-                            _.forEach(arrExpand, function(x){
+                            var arrExpand = [].concat(expand);
+                            _.forEach(arrExpand, function (x) {
                                 q.join(x.$entity).with(x.$with);
                             });
                         }
@@ -884,6 +967,7 @@ DataPermissionEventListener.prototype.beforeExecute = function(event, callback)
 module.exports = {
     DataPermissionEventArgs,
     DataPermissionEventListener,
+    DataPermissionExclusion,
     PermissionMask
 };
 

--- a/model-schema.json
+++ b/model-schema.json
@@ -266,6 +266,10 @@
                                         "filter": {
                                             "type": "string",
                                             "description": "A string which represents a filter expression for this privilege. This attribute is used for self privileges which are commonly derived from user's attributes e.g. 'owner eq me()' or 'orderStatus eq 1 and customer eq me()' etc."
+                                        },
+                                        "exclude": {
+                                            "type": "string",
+                                            "description": "A string which represents an expression for excluding this privilege based on current context. This attribute is used only for privileges of type \"self\" e.g. \"context/user/authenticationScope eq 'sales'\" etc"
                                         }
                                     },
                                     "required": [
@@ -555,6 +559,10 @@
                                 "filter": {
                                     "type": "string",
                                     "description": "A string which represents a filter expression for this privilege. This attribute is used for self privileges which are commonly derived from user's attributes e.g. 'owner eq me()' or 'orderStatus eq 1 and customer eq me()' etc."
+                                },
+                                "exclude": {
+                                    "type": "string",
+                                    "description": "A string which represents an expression for excluding this privilege based on current context. This attribute is used only for privileges of type \"self\" e.g. \"context/user/authenticationScope eq 'sales'\" etc"
                                 }
                             },
                             "required": [
@@ -598,6 +606,10 @@
                     "filter": {
                         "type": "string",
                         "description": "A string which represents a filter expression for this privilege. This attribute is used for self privileges which are commonly derived from user's attributes e.g. 'owner eq me()' or 'orderStatus eq 1 and customer eq me()' etc."
+                    },
+                    "exclude": {
+                        "type": "string",
+                        "description": "A string which represents an expression for excluding this privilege based on current context. This attribute is used only for privileges of type \"self\" e.g. \"context/user/authenticationScope eq 'sales'\" etc"
                     }
                 },
                 "required": [

--- a/model-schema.json
+++ b/model-schema.json
@@ -325,42 +325,52 @@
                         }
                     },
                     "query": {
-                        "type": "object",
+                        "type": "array",
                         "description": "Defines a custom query expression to be used while selecting field.",
-                        "$lookup": {
-                            "type": "object",
-                            "properties": {
-                                "from": {
-                                    "type": "string"
-                                },
-                                "localField": {
-                                    "type": "string"
-                                },
-                                "foreignField": {
-                                    "type": "string"
-                                },
-                                "let": {
+                        "items": {
+                            "anyOf":[
+                                {
                                     "type": "object",
-                                    "additionalProperties": true
+                                    "$lookup": {
+                                        "type": "object",
+                                        "properties": {
+                                            "from": {
+                                                "type": "string"
+                                            },
+                                            "localField": {
+                                                "type": "string"
+                                            },
+                                            "foreignField": {
+                                                "type": "string"
+                                            },
+                                            "let": {
+                                                "type": "object",
+                                                "additionalProperties": true
+                                            },
+                                            "pipeline": {
+                                                "type": "object",
+                                                "additionalProperties": true
+                                            },
+                                            "as": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "additionalProperties": true,
+                                        "required": [
+                                            "from"
+                                        ],
+                                        "description": "A query expression for joining other data models"
+                                    }
                                 },
-                                "pipeline": {
+                                {
                                     "type": "object",
-                                    "additionalProperties": true
-                                },
-                                "as": {
-                                    "type": "string"
+                                    "$project": {
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "description": "A query expression for selecting field"
+                                    }
                                 }
-                            },
-                            "additionalProperties": true,
-                            "required": [
-                                "from"
-                            ],
-                            "description": "A query expression for joining other data models"
-                        },
-                        "$project": {
-                            "type": "object",
-                            "additionalProperties": true,
-                            "description": "A query expression for selecting field"
+                            ]
                         }
                     }
                 },

--- a/model-schema.json
+++ b/model-schema.json
@@ -267,9 +267,12 @@
                                             "type": "string",
                                             "description": "A string which represents a filter expression for this privilege. This attribute is used for self privileges which are commonly derived from user's attributes e.g. 'owner eq me()' or 'orderStatus eq 1 and customer eq me()' etc."
                                         },
-                                        "exclude": {
-                                            "type": "string",
-                                            "description": "A string which represents an expression for excluding this privilege based on current context. This attribute is used only for privileges of type \"self\" e.g. \"context/user/authenticationScope eq 'sales'\" etc"
+                                        "scope": {
+                                            "type": "array",
+                                            "items": {
+                                                "type":"string"
+                                            },
+                                            "description": "An array of OAuth2 client scopes as described here https://oauth.net/2/scope/. If current context does not have any of the provided scopes this privilege will be excluded. This option may be used in OAuth2 authorized environments or in any environment which implements such protocols."
                                         }
                                     },
                                     "required": [
@@ -560,9 +563,12 @@
                                     "type": "string",
                                     "description": "A string which represents a filter expression for this privilege. This attribute is used for self privileges which are commonly derived from user's attributes e.g. 'owner eq me()' or 'orderStatus eq 1 and customer eq me()' etc."
                                 },
-                                "exclude": {
-                                    "type": "string",
-                                    "description": "A string which represents an expression for excluding this privilege based on current context. This attribute is used only for privileges of type \"self\" e.g. \"context/user/authenticationScope eq 'sales'\" etc"
+                                "scope": {
+                                    "type": "array",
+                                    "items": {
+                                        "type":"string"
+                                    },
+                                    "description": "An array of OAuth2 client scopes as described here https://oauth.net/2/scope/. If current context does not have any of the provided scopes this privilege will be excluded. This option may be used in OAuth2 authorized environments or in any environment which implements such protocols."
                                 }
                             },
                             "required": [
@@ -607,9 +613,12 @@
                         "type": "string",
                         "description": "A string which represents a filter expression for this privilege. This attribute is used for self privileges which are commonly derived from user's attributes e.g. 'owner eq me()' or 'orderStatus eq 1 and customer eq me()' etc."
                     },
-                    "exclude": {
-                        "type": "string",
-                        "description": "A string which represents an expression for excluding this privilege based on current context. This attribute is used only for privileges of type \"self\" e.g. \"context/user/authenticationScope eq 'sales'\" etc"
+                    "scope": {
+                        "type": "array",
+                        "items": {
+                            "type":"string"
+                        },
+                        "description": "An array of OAuth2 client scopes as described here https://oauth.net/2/scope/. If current context does not have any of the provided scopes this privilege will be excluded. This option may be used in OAuth2 authorized environments or in any environment which implements such protocols."
                     }
                 },
                 "required": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.8.4",
       "license": "BSD-3-Clause",
       "dependencies": {
+        "@themost/events": "^1.0.5",
         "@themost/promise-sequence": "^1.0.1",
         "async": "^2.6.4",
         "lodash": "^4.17.21",
@@ -2673,6 +2674,11 @@
         "sprintf-js": "^1.1.2",
         "symbol": "^0.3.1"
       }
+    },
+    "node_modules/@themost/events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@themost/events/-/events-1.0.5.tgz",
+      "integrity": "sha512-4G5OcgMXL0z7MdMLvxdvGnt5oXFKOwH3Bv1U4Mn39raO+oRXzT3oF7uip/nRtbXEQLyLgwfyKlOCU97656YLHg=="
     },
     "node_modules/@themost/peers": {
       "version": "1.0.2",
@@ -10296,6 +10302,11 @@
         "sprintf-js": "^1.1.2",
         "symbol": "^0.3.1"
       }
+    },
+    "@themost/events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@themost/events/-/events-1.0.5.tgz",
+      "integrity": "sha512-4G5OcgMXL0z7MdMLvxdvGnt5oXFKOwH3Bv1U4Mn39raO+oRXzT3oF7uip/nRtbXEQLyLgwfyKlOCU97656YLHg=="
     },
     "@themost/peers": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.8.4",
+      "version": "2.8.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/themost-framework/data#readme",
   "dependencies": {
+    "@themost/events": "^1.0.5",
     "@themost/promise-sequence": "^1.0.1",
     "async": "^2.6.4",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/spec/DataPrivilege.exclude.spec.ts
+++ b/spec/DataPrivilege.exclude.spec.ts
@@ -1,0 +1,75 @@
+import {TestUtils} from './adapter/TestUtils';
+import { TestAdapter } from './adapter/TestAdapter';
+import { TestApplication2 } from './TestApplication';
+import { DataContext } from '../types';
+import {DataModelFilterParser} from '../data-model-filter.parser';
+import { at } from 'lodash';
+
+describe('DataPrivilege', () => {
+
+    let app: TestApplication2;
+    let context: DataContext;
+
+    beforeAll(async () => {
+        app = new TestApplication2();
+        context = app.createContext();
+    });
+
+    afterAll(async () => {
+        await context.finalizeAsync();
+        await app.finalize();
+    });
+
+    it('should validate exclude expression', async () => {
+        const Users = context.model('User');
+        Object.assign(context, {
+            user: {
+                name: 'luis.nash@example.com',
+                authenticationScope: 'profile'
+            }
+        })
+        const queryUsers = Users.asQueryable();
+        const parser = new DataModelFilterParser(Users);
+        const addSelect: any[] = [
+            {
+                "name": {
+                    $value: (context as any).user.name
+                }
+            }
+        ];
+        parser.resolvingMember.subscribe(async (event) => {
+            const propertyPath = event.member.split('/');
+            if (propertyPath[0] === 'context') {
+                propertyPath.splice(0, 1);
+                const property = at(context as any, propertyPath.join('.'))[0];
+                const propertyName = propertyPath[propertyPath.length - 1];
+                const exists = addSelect.findIndex((item) => Object.prototype.hasOwnProperty.call(item, propertyPath));
+                if (exists < 0) {
+                    const select = {};
+                    Object.defineProperty(select, propertyName , {
+                        enumerable: true,
+                        configurable: true,
+                        value: {
+                            $value: property
+                        }
+                    })
+                    addSelect.push(select);
+                }
+                event.result = {
+                    $select: "authenticationScope"
+                }
+            }
+        });
+        const q1 = await parser.parseAsync('context/user/authenticationScope eq \'profile\' or context/user/authenticationScope eq \'email\'');
+        expect(q1).toBeTruthy();
+        queryUsers.query.select([].concat(addSelect));
+        Object.assign(queryUsers.query, {
+            $where: q1.$where,
+            $expand: q1.$expand,
+            // $fixed: true
+        });
+        let result: any[] = await (context.db as TestAdapter).executeAsync(queryUsers.query);
+        expect(result).toBeInstanceOf(Array);
+        expect(result.length).toBeTruthy();
+    });
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -88,7 +88,7 @@ export declare interface DataModelPrivilege {
     mask: number;
     account?: string;
     filter?: string;
-    exclude?: string;
+    scope?: string[];
     [k: string]: unknown;
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -88,6 +88,7 @@ export declare interface DataModelPrivilege {
     mask: number;
     account?: string;
     filter?: string;
+    exclude?: string;
     [k: string]: unknown;
 }
 


### PR DESCRIPTION
This PR closes #96 by implementing `DataModelPrivilege.scope` which may be used to exclude privileges defined for specific client scopes. The meaning of "scope" is included in OAuth2 authorised environments but it can be used by any environment which implements such protocols. 
e.g. `Order` model defines a self privilege for giving access to customers for reading their orders. This privilege may be validated only when context includes `orders` or `orders:readonly` scopes.
```
{
            "mask": 1,
            "type": "self",
            "filter": "customer/user eq me()"
            "scope": [
                   "orders",
                   "orders:readonly"
            ]        
}
```