### PR TITLE
Validate visible entity types

### DIFF
--- a/odata.d.ts
+++ b/odata.d.ts
@@ -53,7 +53,7 @@ export declare class EntitySetKind {
 }
 
 export class EdmMapping {
-    static entityType(name: string): Function;
+    static entityType(name?: string): Function;
     static action(name: string, returnType: any): Function;
     static func(name: string, returnType: any): Function;
     static param(name: string, type: string, nullable?: boolean, fromBody?: boolean): Function;

--- a/odata.js
+++ b/odata.js
@@ -1972,32 +1972,69 @@ ODataConventionModelBuilder.prototype._cleanupEntityContainer = function() {
                         }
                         // search entity type collection functions
                         var hasFunction = entityType.collection.functions.find(function(func) {
-                            return func.returnType === entityTypeName ||
-                            func.returnType === EdmType.CollectionOf(entityTypeName);
+                            var exists =  func.returnType === entityTypeName || func.returnCollectionType === entityTypeName;
+                            if (exists) {
+                                return func;
+                            }
+                            exists = func.parameters.find(function(parameter) {
+                                return parameter.type === entityTypeName ||
+                                    parameter.type === EdmType.CollectionOf(entityTypeName);
+                            });
+                            if (exists) {
+                                return func;
+                            }
                         });
                         if (hasFunction) {
                             return item;
                         }
                         // search entity type functions
-                        hasFunction = entityType.functions.find(function(func) {
-                            return func.returnType === entityTypeName ||
-                            func.returnType === EdmType.CollectionOf(entityTypeName);
+                        hasFunction = entityType.functions.find(function tryToFindFunction(func) {
+                            var exists =  func.returnType === entityTypeName || func.returnCollectionType === entityTypeName;
+                            if (exists) {
+                                return func;
+                            }
+                            exists = func.parameters.find(function(parameter) {
+                                return parameter.type === entityTypeName ||
+                                    parameter.type === EdmType.CollectionOf(entityTypeName);
+                            });
+                            if (exists) {
+                                return func;
+                            }
                         });
                         if (hasFunction) {
                             return item;
                         }
+
                         // search entity type collection actions
-                        var hasAction = entityType.collection.actions.find(function(action) {
-                            return action.returnType === entityTypeName ||
-                            action.returnType === EdmType.CollectionOf(entityTypeName);
+                        var hasAction = entityType.collection.actions.find(function tryToFindAction(action) {
+                            var exists = action.returnType === entityTypeName || action.returnCollectionType === entityTypeName;
+                            if (exists) {
+                                return action;
+                            }
+                            exists = action.parameters.find(function(parameter) {
+                                return parameter.type === entityTypeName ||
+                                    parameter.type === EdmType.CollectionOf(entityTypeName);
+                            });
+                            if (exists) {
+                                return action;
+                            }
                         });
                         if (hasAction) {
                             return item;
                         }
                         // search entity type actions
-                        hasAction = entityType.actions.find(function(action) {
-                            return action.returnType === entityTypeName ||
-                            action.returnType === EdmType.CollectionOf(entityTypeName);
+                        hasAction = entityType.actions.find(function tryToFindAction(action) {
+                            var exists = action.returnType === entityTypeName || action.returnCollectionType === entityTypeName;
+                            if (exists) {
+                                return action;
+                            }
+                            exists = action.parameters.find(function(parameter) {
+                                return parameter.type === entityTypeName ||
+                                    parameter.type === EdmType.CollectionOf(entityTypeName);
+                            });
+                            if (exists) {
+                                return action;
+                            }
                         });
                         if (hasAction) {
                             return item;

--- a/odata.js
+++ b/odata.js
@@ -1883,10 +1883,6 @@ ODataConventionModelBuilder.prototype.initialize = function() {
     }
     return Q.promise(function(resolve, reject) {
         try {
-            /**
-             * @type {*|DataConfigurationStrategy}
-             */
-            var dataConfiguration = self.getConfiguration().getStrategy(DataConfigurationStrategy);
             var schemaLoader = self.getConfiguration().getStrategy(SchemaLoaderStrategy);
             if (instanceOf(schemaLoader, DefaultSchemaLoaderStrategy)) {
                 // read models
@@ -1915,20 +1911,8 @@ ODataConventionModelBuilder.prototype.initialize = function() {
                         self.addEntitySet(x, pluralize(x));
                     }
                 });
-                //remove hidden models from entity set container
-                for (var i = 0; i < self[entityContainerProperty].length; i++) {
-                    var x = self[entityContainerProperty][i];
-                    //get model
-                    var entityTypeName = x.entityType.name;
-                    var definition = dataConfiguration.model(x.entityType.name);
-                    if (definition && definition.hidden) {
-                        self.removeEntitySet(x.name);
-                        if (!definition.abstract) {
-                            self.ignore(entityTypeName);
-                        }
-                        i -= 1;
-                    }
-                }
+                self._cleanupEntityContainer();
+                
             }
             self[initializeProperty] = true;
             return resolve();
@@ -1937,6 +1921,63 @@ ODataConventionModelBuilder.prototype.initialize = function() {
         }
     });
 };
+
+ODataConventionModelBuilder.prototype._cleanupEntityContainer = function() {
+    var self = this;
+    // remove hidden models from entity set container
+    /**
+     * @type {*|DataConfigurationStrategy}
+     */
+    var dataConfiguration = self.getConfiguration().getStrategy(DataConfigurationStrategy);
+    /**
+     * @type {Array<EntitySetConfiguration>}
+     */
+    var entityContainer = self[entityContainerProperty];
+    /**
+     * @type {Array<EntityTypeConfiguration>}
+     */
+    var entityTypes = self[entityTypesProperty];
+    for (var i = 0; i < entityContainer.length; i++) {
+        var x = entityContainer[i];
+        // get model
+        var entityTypeName = x.entityType.name;
+        var definition = dataConfiguration.model(x.entityType.name);
+        if (definition && definition.hidden) {
+            self.removeEntitySet(x.name);
+            // keep entity type if it's inherited by other types
+            var find = entityContainer.find(function(item) {
+                return item.entityType && item.entityType.baseType === entityTypeName;
+            });
+            if (find == null) {
+                // keep entity type if it's being as property of an entity
+                find = Object.keys(entityTypes).find(function(item) {
+                    if (Object.prototype.hasOwnProperty.call(entityTypes, item)) {
+                        var entityType = entityTypes[item];
+                        var hasProperty = entityType.property.find(function(property) {
+                            return property.type === entityTypeName;
+                        });
+                        if (hasProperty) {
+                            return item;
+                        }
+                        var hasNavigationProperty = entityType.navigationProperty.find(function(property) {
+                            return property.type === entityTypeName ||
+                                property.type === EdmType.CollectionOf(entityTypeName);
+                        });
+                        if (hasNavigationProperty) {
+                            return item;
+                        }
+                    }
+                    return false;
+                });
+                if (find == null) {
+                    self.ignore(entityTypeName);
+                }
+            }
+            i -= 1;
+        }
+    }
+}
+
 /**
  * @returns *
  */
@@ -2087,12 +2128,9 @@ function EdmMapping() {
  * @returns {Function}
  */
 EdmMapping.entityType = function (name) {
-    if (typeof name !== 'string') {
-        throw new TypeError('Entity type must be a string');
-    }
     return function (target, key, descriptor) {
         if (typeof target === 'function') {
-            target.entityTypeDecorator = name;
+            target.entityTypeDecorator = typeof(name) === 'string' ? name : target.name;
         }
         else {
             throw new Error('Decorator is not valid on this declaration type.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
       },
       "peerDependencies": {
         "@themost/common": "^2",
-        "@themost/query": ">=2.8.1",
+        "@themost/query": ">=2.9.1",
         "@themost/xml": "^2"
       }
     },
@@ -2695,9 +2695,9 @@
       "integrity": "sha512-flTqKuFh1k9JXccwoUskHSjSG81tu0Di/kraNap6dcoQMZyDEgcT9AICu6tyPidWbMilf0bXg5gW1gRjQl5Yiw=="
     },
     "node_modules/@themost/query": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.8.1.tgz",
-      "integrity": "sha512-V3Zx0hUwyR/yarWgMYs/F7sKvpVBkqfnW8MY5+E77JVAgDE6LaXUWmDI/NxJyTRhR7zZXLGoD66I0lYPw+4j2w==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.9.1.tgz",
+      "integrity": "sha512-uhBxq4ftMe9GDJunkqoylj+OX5Mz9NnDHSSHyEDU6b02+KPcTtPxd1w92eL+GEJ3gAt7BuN1hQb08XDLeq+vlQ==",
       "peer": true,
       "dependencies": {
         "@themost/events": "^1.0.5",
@@ -10316,9 +10316,9 @@
       "integrity": "sha512-flTqKuFh1k9JXccwoUskHSjSG81tu0Di/kraNap6dcoQMZyDEgcT9AICu6tyPidWbMilf0bXg5gW1gRjQl5Yiw=="
     },
     "@themost/query": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.8.1.tgz",
-      "integrity": "sha512-V3Zx0hUwyR/yarWgMYs/F7sKvpVBkqfnW8MY5+E77JVAgDE6LaXUWmDI/NxJyTRhR7zZXLGoD66I0lYPw+4j2w==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.9.1.tgz",
+      "integrity": "sha512-uhBxq4ftMe9GDJunkqoylj+OX5Mz9NnDHSSHyEDU6b02+KPcTtPxd1w92eL+GEJ3gAt7BuN1hQb08XDLeq+vlQ==",
       "peer": true,
       "requires": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/spec/ODataModelBuilder.spec.ts
+++ b/spec/ODataModelBuilder.spec.ts
@@ -1,0 +1,69 @@
+import {TestUtils} from './adapter/TestUtils';
+import { TestAdapter } from './adapter/TestAdapter';
+import { TestApplication2 } from './TestApplication';
+import { DataContext } from '../types';
+import {DataModelFilterParser} from '../data-model-filter.parser';
+import { at } from 'lodash';
+import { DataPermissionExclusion } from '../data-permission';
+import { DataConfigurationStrategy } from '../data-configuration';
+import { ODataConventionModelBuilder } from '../odata';
+import { XDocument } from '@themost/xml';
+
+describe('ODataModelBuilder', () => {
+
+    let app: TestApplication2;
+    let context: DataContext;
+
+    beforeAll(async () => {
+        app = new TestApplication2();
+        context = app.createContext();
+    });
+
+    afterAll(async () => {
+        await context.finalizeAsync();
+        await app.finalize();
+    });
+
+    it('should get metadata', async () => {
+        const service: ODataConventionModelBuilder = new ODataConventionModelBuilder(app.getConfiguration());
+        const document = await service.getEdm();
+        expect(document).toBeTruthy();
+    });
+
+    it('should exclude hidden entity types', async () => {
+        const service: ODataConventionModelBuilder = new ODataConventionModelBuilder(app.getConfiguration());
+        const document = await service.getEdm();
+        expect(document).toBeTruthy();
+        let entitySet = document.entityContainer.entitySet.find((item) => item.entityType.name === 'User');
+        expect(entitySet).toBeTruthy();
+        entitySet = document.entityContainer.entitySet.find((item) => item.entityType.name === 'Thing');
+        expect(entitySet).toBeFalsy();
+    });
+
+    it('should get metadata xml', async () => {
+        const service: ODataConventionModelBuilder = new ODataConventionModelBuilder(app.getConfiguration());
+        const document: XDocument = await service.getEdmDocument();
+        expect(document).toBeTruthy();
+
+        let element = document.documentElement.selectSingleNode('edmx:DataServices/Schema/EntityType[@Name=\'User\']');
+        expect(element).toBeTruthy();
+        expect(element.getAttribute('BaseType')).toEqual('Account');
+
+        element = document.documentElement.selectSingleNode('edmx:DataServices/Schema/EntityType[@Name=\'Account\']');
+        expect(element).toBeTruthy();
+        expect(element.getAttribute('BaseType')).toEqual('Thing');
+    });
+
+    it('should include hidden entity types', async () => {
+        const service: ODataConventionModelBuilder = new ODataConventionModelBuilder(app.getConfiguration());
+        const document: XDocument = await service.getEdmDocument();
+        expect(document).toBeTruthy();
+
+        let element = document.documentElement.selectSingleNode('edmx:DataServices/Schema/EntityType[@Name=\'User\']');
+        expect(element).toBeTruthy();
+        expect(element.getAttribute('BaseType')).toEqual('Account');
+
+        element = document.documentElement.selectSingleNode('edmx:DataServices/Schema/EntityType[@Name=\'Thing\']');
+        expect(element).toBeTruthy();
+    });
+});

--- a/spec/ODataModelBuilder.spec.ts
+++ b/spec/ODataModelBuilder.spec.ts
@@ -1,11 +1,5 @@
-import {TestUtils} from './adapter/TestUtils';
-import { TestAdapter } from './adapter/TestAdapter';
 import { TestApplication2 } from './TestApplication';
 import { DataContext } from '../types';
-import {DataModelFilterParser} from '../data-model-filter.parser';
-import { at } from 'lodash';
-import { DataPermissionExclusion } from '../data-permission';
-import { DataConfigurationStrategy } from '../data-configuration';
 import { ODataConventionModelBuilder } from '../odata';
 import { XDocument } from '@themost/xml';
 
@@ -30,7 +24,7 @@ describe('ODataModelBuilder', () => {
         expect(document).toBeTruthy();
     });
 
-    it('should exclude hidden entity types', async () => {
+    it('should exclude hidden entity sets', async () => {
         const service: ODataConventionModelBuilder = new ODataConventionModelBuilder(app.getConfiguration());
         const document = await service.getEdm();
         expect(document).toBeTruthy();

--- a/spec/ODataModelBuilder.spec.ts
+++ b/spec/ODataModelBuilder.spec.ts
@@ -48,16 +48,53 @@ describe('ODataModelBuilder', () => {
         expect(element.getAttribute('BaseType')).toEqual('Thing');
     });
 
-    it('should include hidden entity types', async () => {
+    it('should include hidden entity types when used in functions', async () => {
         const service: ODataConventionModelBuilder = new ODataConventionModelBuilder(app.getConfiguration());
         const document: XDocument = await service.getEdmDocument();
         expect(document).toBeTruthy();
 
-        let element = document.documentElement.selectSingleNode('edmx:DataServices/Schema/EntityType[@Name=\'User\']');
-        expect(element).toBeTruthy();
-        expect(element.getAttribute('BaseType')).toEqual('Account');
+        let functionElement = document.documentElement.selectSingleNode('edmx:DataServices/Schema/Function[@Name=\'Comments\']');
+        expect(functionElement).toBeTruthy();
+        expect(functionElement.selectSingleNode('ReturnType').getAttribute('Type')).toEqual('Collection(UserComment)');
 
-        element = document.documentElement.selectSingleNode('edmx:DataServices/Schema/EntityType[@Name=\'Thing\']');
+        let element = document.documentElement.selectSingleNode('edmx:DataServices/Schema/EntityType[@Name=\'UserComment\']');
         expect(element).toBeTruthy();
+
+        element = document.documentElement.selectSingleNode('edmx:DataServices/Schema/EntityContainer/EntitySet[@EntityType=\'UserComment\']');
+        expect(element).toBeFalsy();
+    });
+
+    it('should include hidden entity types when used in actions', async () => {
+        const service: ODataConventionModelBuilder = new ODataConventionModelBuilder(app.getConfiguration());
+        const document: XDocument = await service.getEdmDocument();
+        expect(document).toBeTruthy();
+
+        let actionElement = document.documentElement.selectSingleNode('edmx:DataServices/Schema/Action[@Name=\'Chats\']');
+        expect(actionElement).toBeTruthy();
+        expect(actionElement.selectSingleNode('ReturnType').getAttribute('Type')).toEqual('Collection(UserChat)');
+
+        let element = document.documentElement.selectSingleNode('edmx:DataServices/Schema/EntityType[@Name=\'UserChat\']');
+        expect(element).toBeTruthy();
+
+        element = document.documentElement.selectSingleNode('edmx:DataServices/Schema/EntityContainer/EntitySet[@EntityType=\'UserChat\']');
+        expect(element).toBeFalsy();
+    });
+
+    it('should include hidden entity types when used in action parameters', async () => {
+        const service: ODataConventionModelBuilder = new ODataConventionModelBuilder(app.getConfiguration());
+        const document: XDocument = await service.getEdmDocument();
+        expect(document).toBeTruthy();
+
+        let actionElement = document.documentElement.selectSingleNode('edmx:DataServices/Schema/Action[@Name=\'Review\']');
+        expect(actionElement).toBeTruthy();
+        const bindingElement = actionElement.selectSingleNode('Parameter[@Name=\'bindingParameter\']');
+        expect(bindingElement).toBeTruthy();
+        expect(bindingElement.getAttribute('Type')).toEqual('User');
+        
+        let element = document.documentElement.selectSingleNode('edmx:DataServices/Schema/EntityType[@Name=\'UserReview\']');
+        expect(element).toBeTruthy();
+
+        element = document.documentElement.selectSingleNode('edmx:DataServices/Schema/EntityContainer/EntitySet[@EntityType=\'UserReview\']');
+        expect(element).toBeFalsy();
     });
 });

--- a/spec/test2/config/models/Thing.json
+++ b/spec/test2/config/models/Thing.json
@@ -6,7 +6,7 @@
     "title": "Thing",
     "abstract": false,
     "sealed": false,
-    "hidden": false,
+    "hidden": true,
     "version": "2.0",
     "fields": [{
             "@id": "http://schema.org/sameAs",

--- a/spec/test2/config/models/User.json
+++ b/spec/test2/config/models/User.json
@@ -101,6 +101,11 @@
                     }
                 ]
             }
+        },
+        {
+            "@id": "https://themost.io/schemas/userReviews",
+            "name": "userReviews",
+            "type": "UserReview"
         }
     ],
     "privileges": [

--- a/spec/test2/config/models/UserChat.json
+++ b/spec/test2/config/models/UserChat.json
@@ -2,7 +2,7 @@
     "$schema": "https://themost-framework.github.io/themost/models/2018/2/schema.json",
     "name": "UserChat",
     "title": "UserChats",
-    "hidden": false,
+    "hidden": true,
     "sealed": false,
     "abstract": false,
     "version": "2.0",

--- a/spec/test2/config/models/UserComment.json
+++ b/spec/test2/config/models/UserComment.json
@@ -2,7 +2,7 @@
     "$schema": "https://themost-framework.github.io/themost/models/2018/2/schema.json",
     "name": "UserComment",
     "title": "UserComments",
-    "hidden": false,
+    "hidden": true,
     "sealed": false,
     "abstract": false,
     "version": "2.0",

--- a/spec/test2/config/models/UserReview.json
+++ b/spec/test2/config/models/UserReview.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://themost-framework.github.io/themost/models/2018/2/schema.json",
+    "name": "UserReview",
+    "title": "UserReviews",
+    "hidden": true,
+    "sealed": false,
+    "abstract": false,
+    "version": "1.0",
+    "inherits": "Review",
+    "fields": [
+        {
+            "name": "user",
+            "type": "User",
+            "nullable": false
+        }
+    ]
+}

--- a/spec/test2/models/Account.ts
+++ b/spec/test2/models/Account.ts
@@ -1,0 +1,11 @@
+import { EdmMapping } from '../../../index';
+import { Thing } from './Thing';
+
+@EdmMapping.entityType()
+class Account extends Thing {
+
+}
+
+export {
+    Account
+}

--- a/spec/test2/models/Thing.ts
+++ b/spec/test2/models/Thing.ts
@@ -1,0 +1,10 @@
+import { EdmMapping, DataObject } from '../../../index';
+
+@EdmMapping.entityType()
+class Thing extends DataObject {
+
+}
+
+export {
+    Thing
+}

--- a/spec/test2/models/User.ts
+++ b/spec/test2/models/User.ts
@@ -27,7 +27,7 @@ class User extends Account {
     @EdmMapping.action('Chats', EdmType.CollectionOf('UserChat'))
     async getChats() {
         const username = this.context.user && this.context.user.name;
-        return this.context.model('UserComment').where((x: { commentBy: { name: string } }) => {
+        return this.context.model('UserChat').where((x: { commentBy: { name: string } }) => {
             return x.commentBy.name === username;
         }, {
             username

--- a/spec/test2/models/User.ts
+++ b/spec/test2/models/User.ts
@@ -1,0 +1,21 @@
+import { DataContext, DataModel, DataQueryable, EdmMapping } from '../../../index';
+import { Account } from './Account';
+
+@EdmMapping.entityType()
+class User extends Account {
+
+    @EdmMapping.func('Me', 'User')
+    static async getMe(context: DataContext) {
+        const username = context.user && context.user.name;
+        return context.model('User').where((x: { name: string }) => {
+            return x.name === username;
+        }, {
+            username
+        });
+    }
+
+}
+
+export {
+    User
+}

--- a/spec/test2/models/User.ts
+++ b/spec/test2/models/User.ts
@@ -1,4 +1,4 @@
-import { DataContext, DataModel, DataQueryable, EdmMapping } from '../../../index';
+import { DataContext, EdmType, EdmMapping } from '../../../index';
 import { Account } from './Account';
 
 @EdmMapping.entityType()
@@ -12,6 +12,37 @@ class User extends Account {
         }, {
             username
         });
+    }
+
+    @EdmMapping.func('Comments', EdmType.CollectionOf('UserComment'))
+    async getComments() {
+        const username = this.context.user && this.context.user.name;
+        return this.context.model('UserComment').where((x: { commentBy: { name: string } }) => {
+            return x.commentBy.name === username;
+        }, {
+            username
+        });
+    }
+
+    @EdmMapping.action('Chats', EdmType.CollectionOf('UserChat'))
+    async getChats() {
+        const username = this.context.user && this.context.user.name;
+        return this.context.model('UserComment').where((x: { commentBy: { name: string } }) => {
+            return x.commentBy.name === username;
+        }, {
+            username
+        });
+    }
+
+    @EdmMapping.param('userReview', 'UserReview', false, true)
+    @EdmMapping.action('Review', 'Object')
+    async review(userReview: any) {
+        await this.context.model('UserReview').save(Object.assign(userReview, {
+            user: this.getId()
+        }));
+        return {
+            id: userReview.id
+        }
     }
 
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -64,8 +64,17 @@ export declare class DataAdapter {
     createView(name:string, query:any, callback:(err?:Error) => void): void;
 }
 
+export declare interface ContextUser {
+    name?: string;
+    authenticationType?: string;
+}
+
 export declare class DataContext extends SequentialEventEmitter {
     
+    user?: ContextUser;
+
+    interactiveUser?: ContextUser;
+
     model(name:any): DataModel
 
     db: DataAdapter;


### PR DESCRIPTION
This PR validates entity types collection when entity set is being ignored -DataMode.hidden equals to true- but the entity type is used by other entity types in properties, navigation properties, functions or actions.

e.g. `UserReview` is a hidden model
```
{
    "$schema": "https://themost-framework.github.io/themost/models/2018/2/schema.json",
    "name": "UserReview",
    "title": "UserReviews",
    "hidden": true,
    "sealed": false,
    "abstract": false,
    "version": "1.0",
    "inherits": "Review",
    "fields": [
        {
            "name": "user",
            "type": "User",
            "nullable": false
        }
    ]
}
```
but is being used as parameter of an action of `User` model.

```
@EdmMapping.param('userReview', 'UserReview', false, true)
    @EdmMapping.action('Review', 'Object')
    async review(userReview: any) {
        await this.context.model('UserReview').save(Object.assign(userReview, {
            user: this.getId()
        }));
        return {
            id: userReview.id
        }
  }
```
So, metadata document should include `UserReview` as entity type.
