### PR TITLE
Include implemented properties while publishing OData service metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.9.1",
+      "version": "2.9.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/spec/ODataModelBuilder.spec.ts
+++ b/spec/ODataModelBuilder.spec.ts
@@ -97,4 +97,17 @@ describe('ODataModelBuilder', () => {
         element = document.documentElement.selectSingleNode('edmx:DataServices/Schema/EntityContainer/EntitySet[@EntityType=\'UserReview\']');
         expect(element).toBeFalsy();
     });
+
+    it('should include implemented properties', async () => {
+        const service: ODataConventionModelBuilder = new ODataConventionModelBuilder(app.getConfiguration());
+        const document: XDocument = await service.getEdmDocument();
+        expect(document).toBeTruthy();
+
+        let element = document.documentElement.selectSingleNode('edmx:DataServices/Schema/EntityType[@Name=\'ActionStatusType\']');
+        expect(element).toBeTruthy();
+
+        let child = element.selectSingleNode('Property[@Name=\'name\']');
+        expect(child).toBeTruthy();
+
+    });
 });


### PR DESCRIPTION
This PR tries to include all properties and navigation properties that are being implemented by a data model while publishing OData service metadata document. 

It also removes any validation for ignoring entity types. This operation of ignoring an entity type defined is completely obsolete and should be removed because it may confuse OData clients while reading service metadata.