### PR TITLE
validate $top and $skip params

### DIFF
--- a/data-model.js
+++ b/data-model.js
@@ -827,14 +827,17 @@ function filterInternal(params, callback) {
 
     try {
 
+        var top = parseInt(params.$top || params.$take, 10);
+        var skip = parseInt(params.$skip, 10);
+        var levels = parseInt(params.$levels, 10)
         var queryOptions = {
             $filter: filter,
             $select:  params.$select,
             $orderBy: params.$orderby || params.$orderBy || params.$order,
-            $groupBy: params.$groupby || params.$groupby || params.$group,
-            $top: params.$top || params.$take,
-            $skip: params.$skip || 0,
-            $levels: parseInt(params.$levels, 10)
+            $groupBy: params.$groupby || params.$groupBy || params.$group,
+            $top: isNaN(top) ? 0 : top,
+            $skip: isNaN(skip) ? 0 : skip,
+            $levels: isNaN(levels) ? -1 : levels
         };
 
         void parser.parseQueryOptions(queryOptions,
@@ -878,13 +881,13 @@ function filterInternal(params, callback) {
                     // prepare query
                     q.query.prepare();
                     // set levels
-                    if (typeof queryOptions.$levels === 'number' && isNaN(queryOptions.$levels) === false) {
+                    if (queryOptions.$levels >= 0) {
                         q.levels(queryOptions.$levels);
                     }
-                    if (typeof queryOptions.$top === 'number') {
+                    if (queryOptions.$top > 0) {
                         q.take(queryOptions.$top);
                     }
-                    if (typeof queryOptions.$skip === 'number') {
+                    if (queryOptions.$skip > 0) {
                         q.skip(queryOptions.$skip);
                     }
                     // set caching

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.9.3",
+      "version": "2.9.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/spec/DataModel.filter.spec.ts
+++ b/spec/DataModel.filter.spec.ts
@@ -1,0 +1,112 @@
+import { TestApplication } from './TestApplication';
+import { DataContext } from '../index';
+import { resolve } from 'path';
+const moment = require('moment');
+
+describe('DataModel.filter', () => {
+    let app: TestApplication;
+    let context: DataContext;
+    beforeAll((done) => {
+        app = new TestApplication(resolve(__dirname, 'test2'));
+        // set default adapter
+        app.getConfiguration().setSourceAt('adapters', [
+            {
+                name: 'test-local',
+                invariantName: 'test',
+                default: true,
+                options: {
+                    database: resolve(__dirname, 'test2/db/local.db')
+                }
+            }
+        ])
+        context = app.createContext();
+        return done();
+    });
+    afterAll(async () => {
+        await context.finalize();
+        await app.finalize();
+    });
+    it('should use $filter param', async () => {
+        await context.executeInTransactionAsync(async () => {
+            const query = await context.model('Product').filterAsync({
+                $filter: 'category eq \'Laptops\'',
+                $orderby: 'name'
+            });
+            const items = await query.getItems();
+            expect(items.length).toBeTruthy();
+            for (const item of items) {
+                expect(item.category).toEqual('Laptops')
+            }
+        });
+    });
+
+    it('should use $take param', async () => {
+        await context.executeInTransactionAsync(async () => {
+            const query = await context.model('Product').filterAsync({
+                $filter: 'category eq \'Laptops\'',
+                $orderby: 'name',
+                $top: '5'
+            });
+            const items = await query.getItems();
+            expect(items.length).toEqual(5);
+        });
+    });
+
+    it('should use $skip param', async () => {
+        await context.executeInTransactionAsync(async () => {
+            let query = await context.model('Product').filterAsync({
+                $filter: 'category eq \'Laptops\'',
+                $orderby: 'name',
+                $top: '10'
+            });
+            const items10 = await query.getItems();
+            expect(items10.length).toEqual(10);
+
+            query = await context.model('Product').filterAsync({
+                $filter: 'category eq \'Laptops\'',
+                $orderby: 'name',
+                $top: '5',
+                $skip: '5'
+            });
+            const items5 = await query.getItems();
+            expect(items5.length).toEqual(5);
+            for (let index = 0; index < items5.length; index++) {
+                const element = items5[index];
+                const findIndex = items10.findIndex((x) => x.id === element.id);
+                expect(findIndex).toEqual(index + 5)
+            }
+
+        });
+    });
+
+    it('should use $levels param', async () => {
+        await context.executeInTransactionAsync(async () => {
+            let query = await context.model('Order').filterAsync({
+                $filter: 'orderedItem/category eq \'Laptops\'',
+                $orderby: 'orderedItem/name',
+                $top: 10,
+                $levels: '1'
+            });
+            expect((query as any).$levels).toEqual(1)
+            let items10 = await query.silent().getItems();
+            expect(items10.length).toEqual(10);
+            for (const item of items10) {
+                expect(typeof item.orderStatus).toEqual('object');    
+            }
+
+            query = await context.model('Order').filterAsync({
+                $filter: 'orderedItem/category eq \'Laptops\'',
+                $orderby: 'orderedItem/name',
+                $top: 10,
+                $levels: 0
+            });
+            expect((query as any).$levels).toEqual(0)
+            items10 = await query.silent().getItems();
+            expect(items10.length).toEqual(10);
+            for (const item of items10) {
+                expect(typeof item.orderStatus).toEqual('number');    
+            }
+        });
+    });
+
+});


### PR DESCRIPTION
This PR validates `$top` and `$skip` while passing those parameters as an argument of `DataModel.filter(queryOptions)` method and parses the given values as integers. 