### PR TITLE
if value is an empty object set associated object to null

### DIFF
--- a/data-associations.js
+++ b/data-associations.js
@@ -126,6 +126,34 @@ class DataObjectAssociationListener {
                                     return cb(new DataObjectAssociationError(mapping.childModel, mapping.childField));
                                 }
                                 else if (result.total === 0) {
+                                    /**
+                                     * this operation will try to validate if the given value represents an empty object
+                                     * e.g. an object with id=0 where `id` is an auto increment identifier
+                                     * the operation didn't find any object, we can set null value 
+                                     * otherwise, throw an exception for missing associated object
+                                     */
+                                    if (isObjectDeep(value) === false) {
+                                        /**
+                                         * @type {import('./types').DataField}
+                                         */
+                                        var parentField = associatedModel.getAttribute(mapping.parentField);
+                                        // try to find parse
+                                        /**
+                                         * @type {function(*)}
+                                         */
+                                        var parser = TypeParser.hasParser(parentField.type);
+                                        if (typeof parser === 'function') {
+                                            // try to parse value
+                                            var converted = parser(null);
+                                            // if the given value is equal that returned by parsing null
+                                            if (converted === value) {
+                                                // set null value
+                                                event.target[childField] = null;
+                                                // and exit
+                                                return cb()
+                                            }
+                                        }
+                                    }
                                     return cb(new DataObjectAssociationError(mapping.childModel, mapping.childField));
                                 }
                                 else if (result.total > 1) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "@types/core-js": "^2.5.0",
         "@types/jest": "^27.4.1",
         "@types/lodash": "^4.14.149",
-        "@types/moment": "^2.13.0",
         "@types/node": "^10.12.0",
         "@types/pluralize": "0.0.29",
         "@types/q": "^1.5.1",
@@ -2833,16 +2832,6 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
       "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==",
       "dev": true
-    },
-    "node_modules/@types/moment": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
-      "integrity": "sha512-DyuyYGpV6r+4Z1bUznLi/Y7HpGn4iQ4IVcGn8zrr1P4KotKLdH0sbK1TFR6RGyX6B+G8u83wCzL+bpawKU/hdQ==",
-      "deprecated": "This is a stub types definition for Moment (https://github.com/moment/moment). Moment provides its own type definitions, so you don't need @types/moment installed!",
-      "dev": true,
-      "dependencies": {
-        "moment": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "10.17.60",
@@ -10460,15 +10449,6 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
       "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==",
       "dev": true
-    },
-    "@types/moment": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
-      "integrity": "sha512-DyuyYGpV6r+4Z1bUznLi/Y7HpGn4iQ4IVcGn8zrr1P4KotKLdH0sbK1TFR6RGyX6B+G8u83wCzL+bpawKU/hdQ==",
-      "dev": true,
-      "requires": {
-        "moment": "*"
-      }
     },
     "@types/node": {
       "version": "10.17.60",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.9.4",
+      "version": "2.9.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@types/core-js": "^2.5.0",
     "@types/jest": "^27.4.1",
     "@types/lodash": "^4.14.149",
-    "@types/moment": "^2.13.0",
     "@types/node": "^10.12.0",
     "@types/pluralize": "0.0.29",
     "@types/q": "^1.5.1",

--- a/spec/DataAttributeResolver.spec.ts
+++ b/spec/DataAttributeResolver.spec.ts
@@ -126,14 +126,14 @@ describe('DataAttributeResolver', () => {
 
     it('should get nested item', async () => {
         await TestUtils.executeInTransaction(context, async () => {
+            Object.assign(context, {
+                user: null
+            });
             const product = await context.model('Product').asQueryable().silent().getItem();
             product.productImage = {
                 url: '/images/products/abc.png'
             }
             await context.model('Product').silent().save(product);
-            Object.assign(context, {
-                user: null
-            });
             let item = await context.model('Product').where('id').equal(product.id).getItem();
             expect(item.productImage).toBeTruthy();
         });

--- a/spec/FunctionContext.spec.ts
+++ b/spec/FunctionContext.spec.ts
@@ -97,7 +97,19 @@ describe('FunctionContext', () => {
                 ).getItem();
             expect(item).toBeTruthy();
             expect(item.createdBy).toEqual(null);
+        });
+    });
 
+    it('should validate filter permission', async() => {
+        await TestUtils.executeInTransaction(context, async () => {
+            context.user = null;
+            const newItem = {
+                "name": "A new subscription"
+            };
+            await context.model('SubscribeAction').silent().save(newItem);
+            const items: any[] = await context.model('SubscribeAction').asQueryable().getItems();
+            expect(items).toBeTruthy();
+            expect(items.length).toEqual(0);
         });
     });
 

--- a/spec/FunctionContext.spec.ts
+++ b/spec/FunctionContext.spec.ts
@@ -3,6 +3,7 @@ import { FunctionContext } from '../functions';
 import { DataContext } from '../types';
 import { TestApplication } from './TestApplication';
 import { Guid } from '@themost/common';
+import { TestUtils } from './adapter/TestUtils';
 
 describe('FunctionContext', () => {
     let app: TestApplication;
@@ -81,6 +82,23 @@ describe('FunctionContext', () => {
         });
         const value = await functionContext.user();
         expect(value).toBeTruthy();
+    });
+
+    it('should use undefined user', async() => {
+        await TestUtils.executeInTransaction(context, async () => {
+            context.user = null;
+            await context.model('EventStatusType').silent().save({
+                "name": "Postponed",
+                "alternateName": "postponed",
+                "description": "The event has been postponed."
+            });
+            const item: any = await context.model('EventStatusType').where(
+                (x: any) => x.alternateName === 'postponed'
+                ).getItem();
+            expect(item).toBeTruthy();
+            expect(item.createdBy).toEqual(null);
+
+        });
     });
 
 });

--- a/spec/test2/config/models/SubscribeAction.json
+++ b/spec/test2/config/models/SubscribeAction.json
@@ -13,6 +13,16 @@
         {
             "mask": 15,
             "type": "global"
+        },
+        {
+            "mask": 15,
+            "type": "global",
+            "account": "Administrators"
+        },
+        {
+            "mask": 15,
+            "type": "self",
+            "filter": "createdBy eq me()"
         }
     ]
 }

--- a/spec/test2/config/models/Thing.json
+++ b/spec/test2/config/models/Thing.json
@@ -105,7 +105,7 @@
             "name": "createdBy",
             "title": "createdBy",
             "description": "Created by user.",
-            "type": "Integer",
+            "type": "User",
             "readonly": true,
             "value": "javascript:return this.user();"
         },
@@ -114,7 +114,7 @@
             "name": "modifiedBy",
             "title": "modifiedBy",
             "description": "Last modified by user.",
-            "type": "Integer",
+            "type": "User",
             "readonly": true,
             "value": "javascript:return this.user();",
             "calculation": "javascript:return this.user();"


### PR DESCRIPTION
This MR closes #103 and validates if a given value which defines an associated object represents an empty object e.g. an object  id=0 where `id` is an auto increment identifier etc. 