### PR TITLE
add DataModel.inferStateAsync

### DIFF
--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -55,6 +55,7 @@ export declare class DataModel extends SequentialEventEmitter{
     cast(obj: any, state: number): any;
     save(obj: any): Promise<any>;
     inferState(obj: any, callback: (err?: Error, res?: any) => void): void;
+    inferStateAsync(obj: any): Promise<any>;
     getSuperTypes(): Array<string>;
     update(obj: any): Promise<any>;
     insert(obj: any): Promise<any>;

--- a/data-model.js
+++ b/data-model.js
@@ -1699,6 +1699,23 @@ DataModel.prototype.inferState = function(obj, callback) {
     });
 };
 /**
+ * 
+ * @param {*} obj 
+ * @returns {Promise<*>}
+ */
+DataModel.prototype.inferStateAsync = function(obj) {
+    var self = this;
+    return new Promise(function(resolve, reject) {
+        self.inferState(obj, function(err, result) {
+            if (err) {
+                return reject(err);
+            }
+            return resolve(result);
+        });
+    });
+};
+
+/**
  * @this DataModel
  * @param {*} obj
  * @param {Function} callback

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR adds `DataModel.inferStateAsync(object)` method which is a promise-like alternative of `DataModel.inferState(object,callback)`.