### PR TITLE
select data view

### DIFF
--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -4,7 +4,7 @@ import {SequentialEventEmitter} from "@themost/common";
 import {DataQueryable} from "./data-queryable";
 import {DataObject} from "./data-object";
 
-export declare class DataModel extends SequentialEventEmitter{
+export declare class DataModel extends SequentialEventEmitter {
     constructor(obj:any);
 
     name: string;
@@ -72,7 +72,7 @@ export declare class DataModel extends SequentialEventEmitter{
     getSubTypes(): Promise<string>;
     getReferenceMappings(deep?: boolean): Array<any>;
     getAttribute(name: string): DataField;
-    getTypedItems(): Promise<DataObject|any>;
+    getTypedItems(): Promise<any>;
     getItems(): Promise<any>;
     getTypedList():Promise<any>;
     upsert(obj: any | Array<any>): Promise<any>;

--- a/data-queryable.js
+++ b/data-queryable.js
@@ -782,7 +782,7 @@ DataQueryable.prototype.select = function(attr) {
                         if (field.many || (field.mapping && field.mapping.associationType === 'junction'))
                             self.expand(field.name);
                         else
-                            arr.push(self.fieldOf(field.name));
+                            arr.push(self.fieldOf(field.name, x.property));
                     }
                     else {
                         var b = DataAttributeResolver.prototype.testAggregatedNestedAttribute.call(self,name);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.10.1",
+      "version": "2.10.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "@themost/common": "^2",
+        "@themost/common": "^2.10.1",
         "@themost/query": ">=2.9.12",
         "@themost/xml": "^2"
       }
@@ -2661,9 +2661,9 @@
       }
     },
     "node_modules/@themost/common": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/@themost/common/-/common-2.7.5.tgz",
-      "integrity": "sha512-HrMaQ3p6YXQk9J2ge//qsfnl8jozVOlPl1YEPM55Rc/8Ay7tSl/ak3Z75nyb/1C8gPLaOzRxsvbQnR+8CFXFSA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@themost/common/-/common-2.10.1.tgz",
+      "integrity": "sha512-M6udS9a9l0vYeXUPXqJzmZcQjbDujrOhZxm0Mfs/lz/gBMzTH0PeCToY5tAZnDdNQN0Tn+5NDoRxa5TG5FqoQw==",
       "peer": true,
       "dependencies": {
         "async": "^2.6.4",
@@ -10292,9 +10292,9 @@
       }
     },
     "@themost/common": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/@themost/common/-/common-2.7.5.tgz",
-      "integrity": "sha512-HrMaQ3p6YXQk9J2ge//qsfnl8jozVOlPl1YEPM55Rc/8Ay7tSl/ak3Z75nyb/1C8gPLaOzRxsvbQnR+8CFXFSA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@themost/common/-/common-2.10.1.tgz",
+      "integrity": "sha512-M6udS9a9l0vYeXUPXqJzmZcQjbDujrOhZxm0Mfs/lz/gBMzTH0PeCToY5tAZnDdNQN0Tn+5NDoRxa5TG5FqoQw==",
       "peer": true,
       "requires": {
         "async": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "install-peers": "add-peers"
   },
   "peerDependencies": {
-    "@themost/common": "^2",
+    "@themost/common": "^2.10.1",
     "@themost/query": ">=2.9.12",
     "@themost/xml": "^2"
   },

--- a/types.d.ts
+++ b/types.d.ts
@@ -111,7 +111,7 @@ export declare class DataAssociationMapping implements DataAssociationMappingBas
     refersTo?: string;
     associationObjectField?: string;
     associationValueField?: string;
-    cascade?: any;
+    cascade?: 'delete' | 'none';
     associationType?: 'association' | 'junction';
     select?: Array<string>;
     privileges?: Array<DataModelPrivilege>;
@@ -157,7 +157,7 @@ export declare class DataField {
     help?: string;
     validation?: any;
     virtual?: boolean;
-    multiplicity?: string;
+    multiplicity?: 'ZeroOrOne' | 'Many' | 'One' | 'Unknown';
     indexed?: boolean;
     size?: number;
     query?: QueryPipelineStage[];


### PR DESCRIPTION
This PR fixes a compatibility issue occurred while selecting a data view defined in a data model. This issue refers to `DataModel.filter()` method which uses `OpenDataParser` instead of internal select methods which were being used in previous versions.