### PR TITLE
fix selection of expandable attributes

### DIFF
--- a/data-model.js
+++ b/data-model.js
@@ -883,6 +883,28 @@ function filterInternal(params, callback) {
                                 }
                             }
                         }
+                        // resolve a backward compatibility issue
+                        // convert select attributes which define an association to expandable attributes
+                        if (Array.isArray(query.$select)) {
+                            var removeCollectionRegex = new RegExp('^' + collection + '.', 'ig');
+                            for (var index = 0; index < query.$select.length; index++) {
+                                var selectElement = query.$select[index];
+                                if (Object.prototype.hasOwnProperty.call(selectElement, '$name')) {
+                                    // get attribute name
+                                    if (typeof selectElement.$name === 'string') {
+                                        var selectAttributeName= selectElement.$name.replace(removeCollectionRegex, '');
+                                        var selectAttribute = self.getAttribute(selectAttributeName);
+                                        if (selectAttribute && selectAttribute.many) {
+                                            // expand attribute
+                                            q.expand(selectAttributeName);
+                                            // and 
+                                            query.$select.splice(index, 1);
+                                            index -= 1;
+                                        }
+                                    }
+                                }
+                            }
+                        }
                         if (view != null) {
                             // select view
                             q.select(view.name)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.10.6",
+  "version": "2.10.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.10.6",
+      "version": "2.10.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.10.6",
+  "version": "2.10.7",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/spec/DataAssociationMapping.spec.ts
+++ b/spec/DataAssociationMapping.spec.ts
@@ -169,5 +169,42 @@ describe('DataAssociationMapping', () => {
         expect(item.groups.length).toBeGreaterThan(1);
     });
 
+    it('should select expandable attribute', async () => {
+        Object.assign(context, {
+            user: {
+                name: 'alexis.rees@example.com'
+            }
+        });
+        let items = await context.model('User').asQueryable()
+            .select(
+                'id',
+                'name',
+                'groups'
+            ).take(25).getItems();
+        expect(items.length).toBeGreaterThan(0);
+        for (const item of items) {
+            expect(item.groups).toBeInstanceOf(Array);
+        }
+    });
+
+    it('should use $select with expandable attribute', async () => {
+        Object.assign(context, {
+            user: {
+                name: 'alexis.rees@example.com'
+            }
+        });
+        const users = context.model('User');
+        const query = await users.filterAsync({
+            '$select': 'id,groups,name',
+            '$top': 25,
+            '$expand': 'groups'
+        })
+        let items = await query.getItems();
+        expect(items.length).toBeGreaterThan(0);
+        for (const item of items) {
+            expect(item.groups).toBeInstanceOf(Array);
+        }
+    });
+
     
 });

--- a/spec/ParentChildRelationship.spec.ts
+++ b/spec/ParentChildRelationship.spec.ts
@@ -38,8 +38,11 @@ describe('ParentChildRelationship', () => {
                 branchCode: '001'
             }
             await context.model('Place').silent().save(newItem);
-            const item = await context.model('Place').where('name').equal(newItem.name)
-                .expand('containedIn').silent().getItem();
+            const item = await context.model('Place').where((x: any, name: string) => {
+                return x.name === name;
+            }, {
+                name: newItem.name
+            }).expand((x: any) => x.containedIn).silent().getItem();
             expect(Object.prototype.hasOwnProperty.call(item, 'containedIn')).toBeTruthy();
             expect(item.containedIn).toEqual(null);
         });


### PR DESCRIPTION
This PR fixes a backward compatibility issue of selecting attributes which define an many-to-many or one-to-many associations. These attributes should be include in `$expand` system query option but sometimes are being used as part of `$select` option.