### PR TITLE
validate already defined expand expressions

### DIFF
--- a/data-model.js
+++ b/data-model.js
@@ -957,6 +957,29 @@ function filterInternal(params, callback) {
                     }
                     // assign join expressions
                     if ($joinExpressions.length>0) {
+                        // concat expand expressions if there are any
+                        var queryExpand = [];
+                        if (Array.isArray(q.query.$expand)) {
+                            queryExpand = q.query.$expand.slice();
+                        } else if (typeof q.query.$expand === 'object') {
+                            queryExpand = [].concat(q.query.$expand)
+                        }
+                        // enumerate already defined expand expressions
+                        // this operation is very important when selecting items from a view
+                        queryExpand.forEach(function(expandExpr) {
+                            // find join expression by entity alias
+                            var joinExpr = $joinExpressions.find(function(x) {
+                                if (x.$entity && x.$entity.$as) {
+                                    return (x.$entity.$as === expandExpr.$entity.$as);
+                                }
+                                return false;
+                            });
+                            // if join expression is not defined then add it
+                            if (joinExpr == null) {
+                                $joinExpressions.push(expandExpr)
+                            }
+                        });
+                        // finally assign join expressions
                         q.query.$expand = $joinExpressions;
                     }
                     // prepare query

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.10.7",
+      "version": "2.11.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/spec/DataModel.filter.spec.ts
+++ b/spec/DataModel.filter.spec.ts
@@ -253,5 +253,27 @@ describe('DataModel.filter', () => {
         });
     });
 
+    it('should use data view with nested columns and expand', async () => {
+        await context.executeInTransactionAsync(async () => {
+            let query = await context.model('Order').filterAsync({
+                $take: 10,
+                $select: 'Delivered',
+                $orderby: 'customer/familyName,customer/givenName,orderedItem/name',
+            });
+            let items = await query.silent().getItems();
+            expect(items).toBeTruthy();
+            expect(items.length).toEqual(10);
+            for (const item of items) {
+                expect(Object.keys(item)).toEqual([
+                    'id',
+                    'orderDate',
+                    'orderedItem',
+                    'customerGivenName',
+                    'customerFamilyName'
+                ]);
+            }
+        });
+    });
+
 
 });


### PR DESCRIPTION
This PR validates expand expressions before adding join expressions extracted by system query options.  This operation is very important when selecting a data model view where attributes may contain join expressions.