### PR TITLE
remove distinct clause

### DIFF
--- a/data-permission.js
+++ b/data-permission.js
@@ -852,7 +852,7 @@ DataPermissionEventListener.prototype.beforeExecute = function(event, callback)
                 else if (expr) {
                     return context.model('Permission').migrate(function(err) {
                         if (err) { return callback(err); }
-                        var q = QueryUtils.query(model.viewAdapter).select([model.primaryKey]).distinct();
+                        var q = QueryUtils.query(model.viewAdapter).select([model.primaryKey]);
                         if (expand) {
                             var arrExpand=[].concat(expand);
                             _.forEach(arrExpand, function(x){

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.43",
+  "version": "2.6.44",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.43",
+  "version": "2.6.44",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR removes `distinct()` clause appears at `DataPermissionListener`:

```javascript
QueryUtils.query(model.viewAdapter).select([model.primaryKey]).distinct();
```

because it 's being used while selecting model's primary key which is always unique. This clause may produce query timeouts and can be safely removed based on what we are selecting.