### PR TITLE
Use data object tag if child model is null

### DIFF
--- a/data-ref-object-listener.js
+++ b/data-ref-object-listener.js
@@ -4,6 +4,7 @@ var {HasParentJunction} = require('./has-parent-junction');
 var {DataObjectJunction} = require('./data-object-junction');
 var {DataObjectTag} = require('./data-object-tag');
 var {DataError} = require('@themost/common');
+var {DataConfigurationStrategy} = require('./data-configuration');
 var _ = require('lodash');
 var {hasOwnProperty} = require('./has-own-property');
 
@@ -172,7 +173,27 @@ function beforeRemoveChildConnectedObjects(event, mapping, callback) {
         target = event.model.convert(event.target),
         parentModel =  event.model,
         parentField = parentModel.getAttribute(mapping.parentField);
-    var junction = mapping.childModel != null ? new HasParentJunction(target, mapping) : new DataObjectTag(target, mapping);
+    /**
+     * @type {import('./types').DataContext}
+     */
+    var context = event.model.context;
+    var isDataType = false;
+    // if child model is null, then check if child attribute is a primitive data type   
+    if (mapping.childModel == null) {
+        /**
+         * try to find attribute by using refersTo property
+         * @type {import('./types').DataField}
+         */
+        var childAttribute = event.model.getAttribute(mapping.refersTo);
+        if (childAttribute == null) {
+            return callback(new DataError('E_ATTR', 'Cannot find child attribute', event.model.name, mapping.refersTo));
+        }
+        isDataType = context.getConfiguration().getStrategy(DataConfigurationStrategy).hasDataType(childAttribute.type);
+        if (!isDataType) {
+            return callback(new DataError('E_ATTR', 'Invalid attribute type', event.model.name, mapping.refersTo));
+        }
+    }
+    var junction = isDataType ? new DataObjectTag(target, mapping) : new HasParentJunction(target, mapping);
     return parentModel.where(parentModel.primaryKey).equal(target.getId())
         .select(parentField.name)
         .cache(false)

--- a/data-ref-object-listener.js
+++ b/data-ref-object-listener.js
@@ -2,6 +2,7 @@
 var async = require('async');
 var {HasParentJunction} = require('./has-parent-junction');
 var {DataObjectJunction} = require('./data-object-junction');
+var {DataObjectTag} = require('./data-object-tag');
 var {DataError} = require('@themost/common');
 var _ = require('lodash');
 var {hasOwnProperty} = require('./has-own-property');
@@ -171,7 +172,7 @@ function beforeRemoveChildConnectedObjects(event, mapping, callback) {
         target = event.model.convert(event.target),
         parentModel =  event.model,
         parentField = parentModel.getAttribute(mapping.parentField);
-    var junction = new HasParentJunction(target, mapping);
+    var junction = mapping.childModel != null ? new HasParentJunction(target, mapping) : new DataObjectTag(target, mapping);
     return parentModel.where(parentModel.primaryKey).equal(target.getId())
         .select(parentField.name)
         .cache(false)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/spec/DataObjectTag.spec.ts
+++ b/spec/DataObjectTag.spec.ts
@@ -184,4 +184,20 @@ describe('DataObjectTag', () => {
         });
     });
 
+    it('should try to delete parent', async () => {
+        await TestUtils.executeInTransaction(context, async () => {
+
+            const Users = context.model('User').silent()
+            await Users.save({
+                name: 'test.user@example.com'
+            })
+            let user = await Users.where('name').equal('test.user@example.com').getTypedItem();
+            await user.property('tags').silent().insert([
+                'NewUser',
+                'ValidUser'
+            ]);
+            await expect(Users.remove(user)).resolves.toBeUndefined();
+        });
+    });
+
 });


### PR DESCRIPTION
This PR checks if `mapping.childModel` is null and uses `DataObjectTag` class instead of `HasParentJunction`. This operation is being used while trying to remove an object and its associated values.