### PR TITLE
add load event

### DIFF
--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -2,8 +2,12 @@
 import {DataAssociationMapping, DataContext, DataField} from "./types";
 import {DataModelBase, SequentialEventEmitter} from "@themost/common";
 import {DataQueryable} from "./data-queryable";
+import {SyncSeriesEventEmitter} from '@themost/events';
 
 export declare class DataModel extends SequentialEventEmitter implements DataModelBase {
+
+    static load: SyncSeriesEventEmitter<{ target: DataModel }>;
+
     constructor(obj:any);
 
     name: string;

--- a/data-model.js
+++ b/data-model.js
@@ -34,6 +34,7 @@ var {ZeroOrOneMultiplicityListener} = require('./zero-or-one-multiplicity');
 var {OnNestedQueryListener} = require('./OnNestedQueryListener');
 var {OnExecuteNestedQueryable} = require('./OnExecuteNestedQueryable');
 var {hasOwnProperty} = require('./has-own-property');
+var { SyncSeriesEventEmitter } = require('@themost/events');
 require('@themost/promise-sequence');
 var DataObjectState = types.DataObjectState;
 /**
@@ -564,7 +565,9 @@ DataModel.prototype.getDataObjectType = function() {
  * Initializes the current data model. This method is used for extending the behaviour of an install of DataModel class.
  */
 DataModel.prototype.initialize = function() {
-    //
+    DataModel.load.emit({
+        target: this
+    });
 };
 
 /**
@@ -3314,6 +3317,8 @@ DataModel.prototype.upsertAsync = function(obj) {
         });
     });
 }
+
+DataModel.load = new SyncSeriesEventEmitter();
 
 module.exports = {
     DataModel

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.11.5",
+  "version": "2.11.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.11.5",
+  "version": "2.11.6",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/spec/DataModel.spec.ts
+++ b/spec/DataModel.spec.ts
@@ -1,6 +1,7 @@
 import {DataModel, EdmMapping, DataContext} from '../index';
 import { TestApplication } from './TestApplication';
 import { resolve } from 'path';
+import {SqliteAdapter} from '@themost/sqlite';
 
 class Employee {
     public EmployeeID?: number;
@@ -69,7 +70,7 @@ describe('DataModel', () => {
     });
 
     it('should use migrateAsync', async () => {
-        const db: TestAdapter = context.db as TestAdapter;
+        const db = context.db as SqliteAdapter;
         let exists = await db.table('OtherProducts').existsAsync();
         expect(exists).toBeFalsy();
         const upgraded = await context.model('OtherProduct').migrateAsync();
@@ -81,6 +82,16 @@ describe('DataModel', () => {
         expect(configuration.cache.OtherProduct).toEqual({
             version
         });
+    });
+
+    it('should use load event', async () => {
+        DataModel.load.subscribeOnce((event) => {
+            event.target.caching = 'always';
+        });
+        let model = context.model('Employee');
+        expect(model.caching).toBe('always');
+        model = context.model('Employee');
+        expect(model.caching).toBe('none');
     });
 
 });


### PR DESCRIPTION
This PR adds `DataModel.load` global event emitter for handling post loading process.

e.g. the following example uses `DataModel.load` event to force data caching for any model:

```javascript
// force caching for any model
DataModel.load.subscribe((event) => {
    event.target.caching = 'always';
});
let model = context.model('Product');
```