### PR TITLE
add load event

### DIFF
--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -3,8 +3,12 @@ import {DataAssociationMapping, DataContext, DataField} from "./types";
 import {SequentialEventEmitter} from "@themost/common";
 import {DataQueryable} from "./data-queryable";
 import {DataObject} from "./data-object";
+import {SyncSeriesEventEmitter} from '@themost/events';
 
 export declare class DataModel extends SequentialEventEmitter{
+
+    static load: SyncSeriesEventEmitter<{ target: DataModel }>;
+
     constructor(obj:any);
 
     name: string;

--- a/data-model.js
+++ b/data-model.js
@@ -35,6 +35,7 @@ var {ZeroOrOneMultiplicityListener} = require('./zero-or-one-multiplicity');
 var {OnNestedQueryListener} = require('./OnNestedQueryListener');
 var {OnExecuteNestedQueryable} = require('./OnExecuteNestedQueryable');
 var {hasOwnProperty} = require('./has-own-property');
+var {SyncSeriesEventEmitter} = require('@themost/events');
 require('@themost/promise-sequence');
 var DataObjectState = types.DataObjectState;
 /**
@@ -561,7 +562,9 @@ DataModel.prototype.getDataObjectType = function() {
  * Initializes the current data model. This method is used for extending the behaviour of an install of DataModel class.
  */
 DataModel.prototype.initialize = function() {
-    //
+    DataModel.load.emit({
+        target: this
+    });
 };
 
 /**
@@ -3219,6 +3222,8 @@ DataModel.prototype.upsertAsync = function(obj) {
         });
     });
 }
+
+DataModel.load = new SyncSeriesEventEmitter();
 
 module.exports = {
     DataModel

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.47",
+  "version": "2.6.48",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.47",
+  "version": "2.6.48",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "types": "index.d.ts",

--- a/spec/DataModel.spec.ts
+++ b/spec/DataModel.spec.ts
@@ -86,4 +86,14 @@ describe('DataModel', () => {
         });
     });
 
+    it('should use load event', async () => {
+        DataModel.load.subscribeOnce((event) => {
+            event.target.caching = 'always';
+        });
+        let model = context.model('Employee');
+        expect(model.caching).toBe('always');
+        model = context.model('Employee');
+        expect(model.caching).toBe('none');
+    });
+
 });


### PR DESCRIPTION
This PR adds `DataModel.load` global event emitter for handling post loading process.

e.g. the following example uses `DataModel.load` event to force data caching for any model:

```javascript
// force caching for any model
DataModel.load.subscribe((event) => {
    event.target.caching = 'always';
});
let model = context.model('Product');
```