### PR TITLE
handle association object mapping with filter

### DIFF
--- a/OnNestedQueryOptionsListener.js
+++ b/OnNestedQueryOptionsListener.js
@@ -1,0 +1,146 @@
+const { QueryExpression } = require('@themost/query');
+// eslint-disable-next-line no-unused-vars
+const { DataEventArgs } = require('./types');
+const { instanceOf } = require('./instance-of');
+require('@themost/promise-sequence');
+
+
+/**
+ * @implements {BeforeExecuteEventListener}
+ */
+class OnNestedQueryOptionsListener {
+    /**
+     * 
+     * @param {DataEventArgs} event
+     * @param {function} callback 
+     */
+    beforeExecute(event, callback) {
+        OnNestedQueryOptionsListener.prototype.beforeExecuteAsync(event).then(function () {
+            return callback();
+        }).catch(function (err) {
+            return callback(err);
+        });
+    }
+
+    beforeExecuteAsync(event) {
+        const query = event.emitter && event.emitter.query;
+        const context = event.model.context;
+        if (query == null) {
+            return Promise.resolve();
+        }
+        // handle only select statements
+        if (query.$select == null) {
+            return Promise.resolve();
+        }
+        if (Object.prototype.hasOwnProperty.call(query, '$expand')) {
+            // exit if expand is null or undefined
+            if (query.$expand == null) {
+                return Promise.resolve();
+            }
+            /**
+             * @type {Array<{ $entity:{ model:string }}>}
+             */
+            const expand = Array.isArray(query.$expand) ? query.$expand : [query.$expand];
+            if (expand.length) {
+                const sources = expand.map(function (item) {
+                    return function () {
+                        // if entity is already a query expression
+                        if (instanceOf(item.$entity, QueryExpression)) {
+                            // do nothing
+                            return Promise.resolve();
+                        }
+                        if (item.$entity && item.$entity.model) {
+                            // get entity alias (which is a field of current model) 
+                            let options = null;
+                            if (item.$entity.$as != null) {
+                                // get current model
+                                let currentModel = event.model;
+                                /**
+                                 * get attribute by name e.g. products.getAttributes('productionDescription')
+                                 * @type {DataField}
+                                 */
+                                let attribute = currentModel.getAttribute(item.$entity.$as);
+                                if (attribute == null) {
+                                    if (item.$with) {
+                                        // find another join by name
+                                        const [key] = Object.keys(item.$with);
+                                        if (key) {
+                                            // get name e.g. orderedItem.id => orderedItem
+                                            const [name] = key.split('.');
+                                            if (name) {
+                                                // find expand by name (which is join alias)
+                                                // e.g. expand.find(x => x.$entity.$as === 'orderedItem')
+                                                const findExpand = expand.find((x) => x.$entity.$as === name);
+                                                if (findExpand) {
+                                                    // get model by name
+                                                    // e.g. context.model('Producn')
+                                                    currentModel = context.model(findExpand.$entity.model);
+                                                    if (currentModel) {
+                                                        // get attribute by name
+                                                        // e.g. products.getAttributes('productionDescription')
+                                                        attribute = currentModel.getAttribute(item.$entity.$as);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                    if (attribute == null) {
+                                        return Promise.resolve();
+                                    }
+                                }
+                                const mapping = currentModel.inferMapping(attribute.name);
+                                if (mapping == null) {
+                                    return Promise.resolve();
+                                }
+                                options = mapping.options;
+                                if (options == null) {
+                                    return Promise.resolve();
+                                }
+                                if (options.$filter == null) {
+                                    return Promise.resolve();
+                                }
+                            }
+                            /**
+                             * @type {import('./data-model').DataModel}
+                             */
+                            const nestedModel = context.model(item.$entity.model);
+                            // if model exists
+                            if (nestedModel != null) {
+                                if (item.$entity.$as != null) {
+                                    // change view to follow entity alias defined by the current query
+                                    // this operation will be used while parsing filter and creating a new query expression
+                                    nestedModel.view = item.$entity.$as;
+                                }
+                                return nestedModel.filterAsync(options).then((q) => {
+                                    /**
+                                     * @typedef {object} QueryExpressionWithPrepared
+                                     * @property {*} $prepared
+                                     */
+                                    /** @type {QueryExpressionWithPrepared} */
+                                    const { query } = q;
+                                    if (query && query.$prepared) {
+                                        item.$with = {
+                                            $and: [
+                                                item.$with,
+                                                query.$prepared
+                                            ]
+                                        }
+                                    }
+                                    return Promise.resolve();
+                                });
+                            }
+                        }
+                        return Promise.resolve();
+                    }
+                });
+                return Promise.sequence(sources);
+            }
+        }
+        return Promise.resolve();
+    }
+
+}
+
+module.exports = {
+    OnNestedQueryOptionsListener
+}

--- a/data-model.js
+++ b/data-model.js
@@ -33,6 +33,7 @@ var {DataField} = require('./types');
 var {ZeroOrOneMultiplicityListener} = require('./zero-or-one-multiplicity');
 var {OnNestedQueryListener} = require('./OnNestedQueryListener');
 var {OnExecuteNestedQueryable} = require('./OnExecuteNestedQueryable');
+var {OnNestedQueryOptionsListener} = require('./OnNestedQueryOptionsListener');
 var {hasOwnProperty} = require('./has-own-property');
 var { SyncSeriesEventEmitter } = require('@themost/events');
 require('@themost/promise-sequence');
@@ -627,6 +628,7 @@ function unregisterContextListeners() {
         this.on('before.execute', DataCachingListener.prototype.beforeExecute);
     }
     this.on('before.execute', OnExecuteNestedQueryable.prototype.beforeExecute);
+    this.on('before.execute', OnNestedQueryOptionsListener.prototype.beforeExecute);
     this.on('before.execute', OnNestedQueryListener.prototype.beforeExecute);
     //register after execute caching
     if (this.caching==='always' || this.caching==='conditional') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/spec/test2/config/models/Product.json
+++ b/spec/test2/config/models/Product.json
@@ -193,6 +193,36 @@
                         }
                     ]
                 }
+            },
+            {
+                "name": "productDescription",
+                "type": "ProductDescription",
+                "readonly": true,
+                "many": true,
+                "multiplicity": "ZeroOrOne",
+                "mapping": {
+                    "parentModel": "Product",
+                    "parentField": "id",
+                    "childModel": "ProductDescription",
+                    "childField": "product",
+                    "associationType": "association",
+                    "options": {
+                        "$filter" : "inLanguage eq lang()"
+                    }
+                }
+            },
+            {
+                "name": "productDescriptions",
+                "type": "ProductDescription",
+                "nested": true,
+                "mapping": {
+                    "parentModel": "Product",
+                    "parentField": "id",
+                    "childModel": "ProductDescription",
+                    "childField": "product",
+                    "associationType": "association",
+                    "cascade": "delete"
+                }
             }
     ],
     "constraints": [

--- a/spec/test2/config/models/ProductDescription.json
+++ b/spec/test2/config/models/ProductDescription.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "https://themost-framework.github.io/themost/models/2018/2/schema.json",
+    "name": "ProductDescription",
+    "title": "ProductDescription",
+    "version": "2.0",
+    "inherits": "StructuredValue",
+    "fields": [
+        {
+            "name": "description",
+            "type": "Note"
+        },
+        {
+            "name": "inLanguage",
+            "type": "Text",
+            "size": 5,
+            "nullable": false
+        },
+        {
+            "name": "product",
+            "type": "Product",
+            "nullable": false
+        }
+    ],
+    "constraints": [
+        {
+            "type": "unique",
+            "fields": [
+                "product",
+                "inLanguage"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds a new before execute listener for handling associations where a filter statement defines the condition representing an association between two entities. 

Let's assume that a product has a product description in different languages. `Product` model has also a virtual property `Product.productDescription` which defines the description of a product in current locale.

The collection of product descriptions:

```json
{
    "name": "productDescriptions",
    "type": "ProductDescription",
    "nested": true,
    "mapping": {
        "parentModel": "Product",
        "parentField": "id",
        "childModel": "ProductDescription",
        "childField": "product",
        "associationType": "association",
        "cascade": "delete"
    }
}
``` 

The definition of the `productDescription` property:

```json
{
    "name": "productDescription",
    "type": "ProductDescription",
    "readonly": true,
    "many": true,
    "multiplicity": "ZeroOrOne",
    "mapping": {
        "parentModel": "Product",
        "parentField": "id",
        "childModel": "ProductDescription",
        "childField": "product",
        "associationType": "association",
        "options": {
            "$filter" : "inLanguage eq lang()"
        }
    }
}
```

where there is a filter condition to query product description based on the language of the current context.

We are trying to query a product and get product description as a nested queryable property `productDescription.description`:

```javascript
const Products = context.model('Product')
let product = await Products.where('name').equal('Samsung Galaxy S4').getItem();

const productDescriptions =  [{
    description: 'This is a new product description',
    inLanguage: 'en'
}, {
    description: 'Ceci est une nouvelle description de produit',
    inLanguage: 'fr'
}];

await Products.silent().save(Object.assign(product, {
    productDescriptions
}));

const item = await Products.select(
    (x: any) => {
        return {
            id: x.id,
            name: x.name,
            productDescription: x.productDescription.description
        }
    }
).where('name').equal('Samsung Galaxy S4').getItem();
```

Finally we are getting product with a description in the current locale.

