### PR TITLE
excluding privileges according to authentication scopes

### DIFF
--- a/data-attribute-resolver.d.ts
+++ b/data-attribute-resolver.d.ts
@@ -1,0 +1,13 @@
+import { QueryEntity, QueryField } from '@themost/query';
+
+export declare class DataAttributeResolver {
+    orderByNestedAttribute(attr: string): any;
+    selectNestedAttribute(attr: string): any;
+    selectAggregatedAttribute(aggregation: string, attribute: string, alias: string): any;
+    resolveNestedAttribute(attr: string): any;
+    resolveNestedAttributeJoin(memberExpr: string): { $select?: QueryField, $expand?: QueryEntity[] };
+    testAttribute(s: string): any;
+    testAggregatedNestedAttribute(s: string): any;
+    testNestedAttribute(s: string): any;
+    resolveJunctionAttributeJoin(attr: string): { $select?: QueryField, $expand?: QueryEntity[] };
+}

--- a/data-attribute-resolver.js
+++ b/data-attribute-resolver.js
@@ -1,0 +1,570 @@
+var {sprintf} = require('sprintf-js');
+var Symbol = require('symbol');
+var _ = require('lodash');
+var {DataError} = require('@themost/common');
+var {QueryField} = require('@themost/query');
+var {QueryEntity} = require('@themost/query');
+var {QueryUtils} = require('@themost/query');
+var aliasProperty = Symbol('alias');
+var {hasOwnProperty} = require('./has-own-property');
+
+
+/**
+ * @class
+ */
+function DataAttributeResolver() {
+
+}
+
+DataAttributeResolver.prototype.orderByNestedAttribute = function(attr) {
+    var nestedAttribute = DataAttributeResolver.prototype.testNestedAttribute(attr);
+    if (nestedAttribute) {
+        var matches = /^(\w+)\((\w+)\/(\w+)\)$/i.exec(nestedAttribute.name);
+        if (matches)   {
+            return DataAttributeResolver.prototype.selectAggregatedAttribute.call(this, matches[1], matches[2] + '/' + matches[3]);
+        }
+        matches = /^(\w+)\((\w+)\/(\w+)\/(\w+)\)$/i.exec(nestedAttribute.name);
+        if (matches)   {
+            return DataAttributeResolver.prototype.selectAggregatedAttribute.call(this, matches[1], matches[2] + '/' + matches[3] + '/' + matches[4]);
+        }
+    }
+    return DataAttributeResolver.prototype.resolveNestedAttribute.call(this, attr);
+};
+
+DataAttributeResolver.prototype.selecteNestedAttribute = function(attr, alias) {
+    var expr = DataAttributeResolver.prototype.resolveNestedAttribute.call(this, attr);
+    if (expr) {
+        if (_.isNil(alias))
+            expr.as(attr.replace(/\//g,'_'));
+        else
+            expr.as(alias)
+    }
+    return expr;
+};
+/**
+ * @param {string} aggregation
+ * @param {string} attribute
+ * @param {string=} alias
+ * @returns {*}
+ */
+DataAttributeResolver.prototype.selectAggregatedAttribute = function(aggregation, attribute, alias) {
+    var self=this, result;
+    if (DataAttributeResolver.prototype.testNestedAttribute(attribute)) {
+        result = DataAttributeResolver.prototype.selecteNestedAttribute.call(self,attribute, alias);
+    }
+    else {
+        result = self.fieldOf(attribute);
+    }
+    var sAlias = result.as(), name = result.getName(), expr;
+    if (sAlias) {
+        expr = result[sAlias];
+        result[sAlias] = { };
+        result[sAlias]['$' + aggregation ] = expr;
+    }
+    else {
+        expr = result.$name;
+        result[name] = { };
+        result[name]['$' + aggregation ] = expr;
+    }
+    return result;
+};
+
+DataAttributeResolver.prototype.resolveNestedAttribute = function(attr) {
+    var self = this;
+    if (typeof attr === 'string' && /\//.test(attr)) {
+        var member = attr.split('/'), expr, arr, obj, select;
+        //change: 18-Feb 2016
+        //description: Support many to many (junction) resolving
+        var mapping = self.model.inferMapping(member[0]);
+        if (mapping && mapping.associationType === 'junction') {
+            var expr1 = DataAttributeResolver.prototype.resolveJunctionAttributeJoin.call(self.model, attr);
+            //select field
+            select = expr1.$select;
+            //get expand
+            expr = expr1.$expand;
+        }
+        else {
+            // create member expression
+            var memberExpr = {
+                name: attr
+            };
+            // and pass member expression
+            expr = DataAttributeResolver.prototype.resolveNestedAttributeJoin.call(self.model, memberExpr);
+            //select field
+            if (member.length>2) {
+                if (memberExpr.name !== attr) {
+                    // get member segments again because they have been modified
+                    member = memberExpr.name.split('/');
+                }
+                select = QueryField.select(member[member.length-1]).from(member[member.length-2]);
+            }
+            else {
+                if (memberExpr.name !== attr) {
+                    // get member segments again because they have been modified
+                    member = memberExpr.name.split('/');
+                }
+                // and create query field expression
+                select  = QueryField.select(member[1]).from(member[0]);
+            }
+        }
+        if (expr) {
+            if (_.isNil(self.query.$expand)) {
+                self.query.$expand = expr;
+            }
+            else {
+                arr = [];
+                if (!_.isArray(self.query.$expand)) {
+                    arr.push(self.query.$expand);
+                    this.query.$expand = arr;
+                }
+                arr = [];
+                if (_.isArray(expr))
+                    arr.push.apply(arr, expr);
+                else
+                    arr.push(expr);
+                arr.forEach(function(y) {
+                    obj = self.query.$expand.find(function(x) {
+                        if (x.$entity && x.$entity.$as) {
+                                return (x.$entity.$as === y.$entity.$as);
+                            }
+                        return false;
+                    });
+                    if (typeof obj === 'undefined') {
+                        self.query.$expand.push(y);
+                    }
+                });
+            }
+            return select;
+        }
+        else {
+            throw new Error('Member join expression cannot be empty at this context');
+        }
+    }
+};
+
+
+/**
+ *
+ * @param {*} memberExpr - A string that represents a member expression e.g. user/id or article/published etc.
+ * @returns {*} - An object that represents a query join expression
+ */
+DataAttributeResolver.prototype.resolveNestedAttributeJoin = function(memberExpr) {
+    var self = this, childField, parentField, res, expr, entity;
+    var memberExprString;
+    if (typeof memberExpr === 'string') {
+        memberExprString = memberExpr;
+    }
+    else if (typeof memberExpr === 'object' && hasOwnProperty(memberExpr, 'name')) {
+        memberExprString = memberExpr.name
+    }
+    if (/\//.test(memberExprString)) {
+        //if the specified member contains '/' e.g. user/name then prepare join
+        var arrMember = memberExprString.split('/');
+        var attrMember = self.field(arrMember[0]);
+        if (_.isNil(attrMember)) {
+            throw new Error(sprintf('The target model does not have an attribute named as %s',arrMember[0]));
+        }
+        //search for field mapping
+        var mapping = self.inferMapping(arrMember[0]);
+        if (_.isNil(mapping)) {
+            throw new Error(sprintf('The target model does not have an association defined for attribute named %s',arrMember[0]));
+        }
+        if (mapping.childModel===self.name && mapping.associationType==='association') {
+            //get parent model
+            var parentModel = self.context.model(mapping.parentModel);
+            if (_.isNil(parentModel)) {
+                throw new Error(sprintf('Association parent model (%s) cannot be found.', mapping.parentModel));
+            }
+            childField = self.field(mapping.childField);
+            if (_.isNil(childField)) {
+                throw new Error(sprintf('Association field (%s) cannot be found.', mapping.childField));
+            }
+            parentField = parentModel.field(mapping.parentField);
+            if (_.isNil(parentField)) {
+                throw new Error(sprintf('Referenced field (%s) cannot be found.', mapping.parentField));
+            }
+            // get childField.name or childField.property
+            var childFieldName = childField.property || childField.name;
+            /**
+             * store temp query expression
+             * @type QueryExpression
+             */
+            res =QueryUtils.query(self.viewAdapter).select(['*']);
+            expr = QueryUtils.query().where(QueryField.select(childField.name)
+                .from(self[aliasProperty] || self.viewAdapter))
+                .equal(QueryField.select(mapping.parentField).from(childFieldName));
+            entity = new QueryEntity(parentModel.viewAdapter).as(childFieldName).left();
+            res.join(entity).with(expr);
+            Object.defineProperty(entity, 'model', {
+                configurable: true,
+                enumerable: false,
+                writable: true,
+                value: parentModel.name
+            });
+            if (arrMember.length>2) {
+                parentModel[aliasProperty] = mapping.childField;
+                expr = DataAttributeResolver.prototype.resolveNestedAttributeJoin.call(parentModel, arrMember.slice(1).join('/'));
+                return [].concat(res.$expand).concat(expr);
+            }
+            //--set active field
+            return res.$expand;
+        }
+        else if (mapping.parentModel===self.name && mapping.associationType==='association') {
+            var childModel = self.context.model(mapping.childModel);
+            if (_.isNil(childModel)) {
+                throw new Error(sprintf('Association child model (%s) cannot be found.', mapping.childModel));
+            }
+            childField = childModel.field(mapping.childField);
+            if (_.isNil(childField)) {
+                throw new Error(sprintf('Association field (%s) cannot be found.', mapping.childField));
+            }
+            parentField = self.field(mapping.parentField);
+            if (_.isNil(parentField)) {
+                throw new Error(sprintf('Referenced field (%s) cannot be found.', mapping.parentField));
+            }
+            // get parent entity name for this expression
+            var parentEntity = self[aliasProperty] || self.viewAdapter;
+            // get child entity name for this expression
+            var childEntity = arrMember[0];
+            res =QueryUtils.query('Unknown').select(['*']);
+            expr = QueryUtils.query().where(QueryField.select(parentField.name).from(parentEntity)).equal(QueryField.select(childField.name).from(childEntity));
+            entity = new QueryEntity(childModel.viewAdapter).as(childEntity).left();
+            res.join(entity).with(expr);
+            Object.defineProperty(entity, 'model', {
+                configurable: true,
+                enumerable: false,
+                writable: true,
+                value: childModel.name
+            });
+            if (arrMember.length>2) {
+                // set joined entity alias
+                childModel[aliasProperty] = childEntity;
+                // resolve additional joins
+                expr = DataAttributeResolver.prototype.resolveNestedAttributeJoin.call(childModel, arrMember.slice(1).join('/'));
+                // concat and return joins
+                return [].concat(res.$expand).concat(expr);
+            } else {
+                // get child model member
+                var childMember = childModel.field(arrMember[1]);
+                if (childMember) {
+                    // try to validate if child member has an alias or not
+                    if (childMember.name !== arrMember[1]) {
+                        arrMember[1] = childMember.name;
+                        // set memberExpr
+                        if (typeof memberExpr === 'object' && Object.prototype.hasOwnProperty.call(memberExpr, 'name')) {
+                            memberExpr.name = arrMember.join('/');
+                        }
+                    }
+                }
+            }
+            return res.$expand;
+        }
+        else {
+            throw new Error(sprintf('The association type between %s and %s model is not supported for filtering, grouping or sorting data.', mapping.parentModel , mapping.childModel));
+        }
+    }
+};
+
+/**
+ * @param {string} s
+ * @returns {*}
+ */
+DataAttributeResolver.prototype.testAttribute = function(s) {
+    if (typeof s !== 'string')
+        return;
+    /**
+     * @private
+     */
+    var matches;
+    /**
+     * attribute aggregate function with alias e.g. f(x) as a
+     * @ignore
+     */
+    matches = /^(\w+)\((\w+)\)\sas\s([\u0020-\u007F\u0080-\uFFFF]+)$/i.exec(s);
+    if (matches) {
+        return { name: matches[1] + '(' + matches[2] + ')' , property:matches[3] };
+    }
+    /**
+     * attribute aggregate function with alias e.g. x as a
+     * @ignore
+     */
+    matches = /^(\w+)\sas\s([\u0020-\u007F\u0080-\uFFFF]+)$/i.exec(s);
+    if (matches) {
+        return { name: matches[1] , property:matches[2] };
+    }
+    /**
+     * attribute aggregate function with alias e.g. f(x)
+     * @ignore
+     */
+    matches = /^(\w+)\((\w+)\)$/i.exec(s);
+    if (matches) {
+        return { name: matches[1] + '(' + matches[2] + ')' };
+    }
+    // only attribute e.g. x
+    if (/^(\w+)$/.test(s)) {
+        return { name: s};
+    }
+};
+
+/**
+ * @param {string} s
+ * @returns {*}
+ */
+DataAttributeResolver.prototype.testAggregatedNestedAttribute = function(s) {
+    if (typeof s !== 'string')
+        return;
+    /**
+     * @private
+     */
+    var matches;
+    /**
+     * nested attribute aggregate function with alias e.g. f(x/b) as a
+     * @ignore
+     */
+    matches = /^(\w+)\((\w+)\/(\w+)\)\sas\s([\u0020-\u007F\u0080-\uFFFF]+)$/i.exec(s);
+    if (matches) {
+        return { aggr: matches[1], name: matches[2] + '/' + matches[3], property:matches[4] };
+    }
+    /**
+     * nested attribute aggregate function with alias e.g. f(x/b/c) as a
+     * @ignore
+     */
+    matches = /^(\w+)\((\w+)\/(\w+)\/(\w+)\)\sas\s([\u0020-\u007F\u0080-\uFFFF]+)$/i.exec(s);
+    if (matches) {
+        return { aggr: matches[1], name: matches[2] + '/' + matches[3] + '/' + matches[4], property:matches[5] };
+    }
+    /**
+     * nested attribute aggregate function with alias e.g. f(x/b)
+     * @ignore
+     */
+    matches = /^(\w+)\((\w+)\/(\w+)\)$/i.exec(s);
+    if (matches) {
+        return { aggr: matches[1], name: matches[2] + '/' + matches[3]  };
+    }
+    /**
+     * nested attribute aggregate function with alias e.g. f(x/b/c)
+     * @ignore
+     */
+    matches = /^(\w+)\((\w+)\/(\w+)\/(\w+)\)$/i.exec(s);
+    if (matches) {
+        return { aggr: matches[1], name: matches[2] + '/' + matches[3] + '/' + matches[4] };
+    }
+};
+
+/**
+ * @param {string} s
+ * @returns {*}
+ */
+DataAttributeResolver.prototype.testNestedAttribute = function(s) {
+    if (typeof s !== 'string')
+        return;
+    /**
+     * @private
+     */
+    var matches;
+    /**
+     * nested attribute aggregate function with alias e.g. f(x/b) as a
+     * @ignore
+     */
+    matches = /^(\w+)\((\w+)\/(\w+)\)\sas\s([\u0020-\u007F\u0080-\uFFFF]+)$/i.exec(s);
+    if (matches) {
+        return { name: matches[1] + '(' + matches[2] + '/' + matches[3]  + ')', property:matches[4] };
+    }
+    /**
+     * nested attribute aggregate function with alias e.g. f(x/b/c) as a
+     * @ignore
+     */
+    matches = /^(\w+)\((\w+)\/(\w+)\/(\w+)\)\sas\s([\u0020-\u007F\u0080-\uFFFF]+)$/i.exec(s);
+    if (matches) {
+        return { name: matches[1] + '(' + matches[2] + '/' + matches[3] + '/' + matches[4]  + ')', property:matches[5] };
+    }
+    /**
+     * nested attribute aggregate function with alias e.g. f(x/b/c/d) as a
+     * @ignore
+     */
+    matches = /^(\w+)\((\w+)\/(\w+)\/(\w+)\/(\w+)\)\sas\s([\u0020-\u007F\u0080-\uFFFF]+)$/i.exec(s);
+    if (matches) {
+        return { name: matches[1] + '(' + matches[2] + '/' + matches[3] + '/' + matches[4] + '/' + matches[5]  + ')', property:matches[6] };
+    }
+    /**
+     * nested attribute with alias e.g. x/b as a
+     * @ignore
+     */
+    matches = /^(\w+)\/(\w+)\sas\s([\u0020-\u007F\u0080-\uFFFF]+)$/i.exec(s);
+    if (matches) {
+        return { name: matches[1] + '/' + matches[2], property:matches[3] };
+    }
+    /**
+     * nested attribute with alias e.g. x/b/c as a
+     * @ignore
+     */
+    matches = /^(\w+)\/(\w+)\/(\w+)\sas\s([\u0020-\u007F\u0080-\uFFFF]+)$/i.exec(s);
+    if (matches) {
+        return { name: matches[1] + '/' + matches[2] + '/' + matches[3], property:matches[4] };
+    }
+    /**
+     * nested attribute with alias e.g. x/b/c/d as a
+     * @ignore
+     */
+    matches = /^(\w+)\/(\w+)\/(\w+)\/(\w+)\sas\s([\u0020-\u007F\u0080-\uFFFF]+)$/i.exec(s);
+    if (matches) {
+        return { name: matches[1] + '/' + matches[2] + '/' + matches[3] + '/' + matches[4], property:matches[5] };
+    }
+    /**
+     * nested attribute aggregate function with alias e.g. f(x/b)
+     * @ignore
+     */
+    matches = /^(\w+)\((\w+)\/(\w+)\)$/i.exec(s);
+    if (matches) {
+        return { name: matches[1] + '(' + matches[2] + '/' + matches[3]  + ')' };
+    }
+    /**
+     * nested attribute aggregate function with alias e.g. f(x/b/c)
+     * @ignore
+     */
+    matches = /^(\w+)\((\w+)\/(\w+)\/(\w+)\)$/i.exec(s);
+    if (matches) {
+        return { name: matches[1] + '('  + matches[2] + '/' + matches[3] + '/' + matches[4]  + ')' };
+    }
+    /**
+     * nested attribute aggregate function with alias e.g. f(x/b/c/d)
+     * @ignore
+     */
+    matches = /^(\w+)\((\w+)\/(\w+)\/(\w+)\/(\w+)\)$/i.exec(s);
+    if (matches) {
+        return { name: matches[1] + '('  + matches[2] + '/' + matches[3] + '/' + matches[4] + matches[5]  + ')' };
+    }
+    /**
+     * nested attribute with alias e.g. x/b
+     * @ignore
+     */
+    matches = /^(\w+)\/(\w+)$/.exec(s);
+    if (matches) {
+        return { name: s };
+    }
+
+    /**
+     * nested attribute with alias e.g. x/b/c
+     * @ignore
+     */
+    matches = /^(\w+)\/(\w+)\/(\w+)$/.exec(s);
+    if (matches) {
+        return { name: s };
+    }
+
+    /**
+     * nested attribute with alias e.g. x/b/c/d
+     * @ignore
+     */
+    matches = /^(\w+)\/(\w+)\/(\w+)\/(\w+)$/.exec(s);
+    if (matches) {
+        return { name: s };
+    }
+
+};
+
+/**
+ * @param {string} attr
+ * @returns {*}
+ */
+DataAttributeResolver.prototype.resolveJunctionAttributeJoin = function(attr) {
+    var self = this, member = attr.split('/');
+    //get the data association mapping
+    var mapping = self.inferMapping(member[0]);
+    //if mapping defines a junction between two models
+    if (mapping && mapping.associationType === 'junction') {
+        //get field
+        var field = self.field(member[0]), entity, expr, q;
+        //first approach (default association adapter)
+        //the underlying model is the parent model e.g. Group > Group Members
+        if (mapping.parentModel === self.name) {
+
+            q =QueryUtils.query(self.viewAdapter).select(['*']);
+            //init an entity based on association adapter (e.g. GroupMembers as members)
+            entity = new QueryEntity(mapping.associationAdapter).as(field.name);
+            //init join expression between association adapter and current data model
+            //e.g. Group.id = GroupMembers.parent
+            expr = QueryUtils.query().where(QueryField.select(mapping.parentField).from(self.viewAdapter))
+                    .equal(QueryField.select(mapping.associationObjectField).from(field.name));
+            //append join
+            q.join(entity).with(expr);
+            //data object tagging
+            if (typeof mapping.childModel === 'undefined') {
+                return {
+                    $expand:[q.$expand],
+                    $select:QueryField.select(mapping.associationValueField).from(field.name)
+                }
+            }
+
+            //return the resolved attribute for futher processing e.g. members.id
+            if (member[1] === mapping.childField) {
+                return {
+                    $expand:[q.$expand],
+                    $select:QueryField.select(mapping.associationValueField).from(field.name)
+                }
+            }
+            else {
+                //get child model
+                var childModel = self.context.model(mapping.childModel);
+                if (_.isNil(childModel)) {
+                    throw new DataError('EJUNC','The associated model cannot be found.');
+                }
+                //create new join
+                var alias = field.name + '_' + childModel.name;
+                entity = new QueryEntity(childModel.viewAdapter).as(alias);
+                expr = QueryUtils.query().where(QueryField.select(mapping.associationValueField).from(field.name))
+                    .equal(QueryField.select(mapping.childField).from(alias));
+                //append join
+                q.join(entity).with(expr);
+                return {
+                    $expand:q.$expand,
+                    $select:QueryField.select(member[1]).from(alias)
+                }
+            }
+        }
+        else {
+            q =QueryUtils.query(self.viewAdapter).select(['*']);
+            //the underlying model is the child model
+            //init an entity based on association adapter (e.g. GroupMembers as groups)
+            entity = new QueryEntity(mapping.associationAdapter).as(field.name);
+            //init join expression between association adapter and current data model
+            //e.g. Group.id = GroupMembers.parent
+            expr = QueryUtils.query().where(QueryField.select(mapping.childField).from(self.viewAdapter))
+                .equal(QueryField.select(mapping.associationValueField).from(field.name));
+            //append join
+            q.join(entity).with(expr);
+            //return the resolved attribute for further processing e.g. members.id
+            if (member[1] === mapping.parentField) {
+                return {
+                    $expand:[q.$expand],
+                    $select:QueryField.select(mapping.associationObjectField).from(field.name)
+                }
+            }
+            else {
+                //get parent model
+                var parentModel = self.context.model(mapping.parentModel);
+                if (_.isNil(parentModel)) {
+                    throw new DataError('EJUNC','The associated model cannot be found.');
+                }
+                //create new join
+                var parentAlias = field.name + '_' + parentModel.name;
+                entity = new QueryEntity(parentModel.viewAdapter).as(parentAlias);
+                expr = QueryUtils.query().where(QueryField.select(mapping.associationObjectField).from(field.name))
+                    .equal(QueryField.select(mapping.parentField).from(parentAlias));
+                //append join
+                q.join(entity).with(expr);
+                return {
+                    $expand:q.$expand,
+                    $select:QueryField.select(member[1]).from(parentAlias)
+                }
+            }
+        }
+    }
+    else {
+        throw new DataError('EJUNC','The target model does not have a many to many association defined by the given attribute.','', self.name, attr);
+    }
+};
+
+module.exports = {
+    DataAttributeResolver
+}

--- a/data-model-filter.parser.d.ts
+++ b/data-model-filter.parser.d.ts
@@ -1,0 +1,9 @@
+import { AsyncSeriesEventEmitter } from '@themost/events';
+import { DataModel } from './data-model';
+
+export declare class DataModelFilterParser {
+    constructor(model: DataModel);
+    resolvingMember: AsyncSeriesEventEmitter<{ target: DataModelFilterParser, member: string, result: { $select: any, $expand?: any } }>;
+    resolvingMethod: AsyncSeriesEventEmitter<{ target: DataModelFilterParser, method: string, args: any, result: any }>;
+    parseAsync(str: string): Promise<{ $where: any, $expand?: any }>;
+}

--- a/data-model-filter.parser.js
+++ b/data-model-filter.parser.js
@@ -1,0 +1,143 @@
+const { AsyncSeriesEventEmitter } = require('@themost/events');
+const { OpenDataParser } = require('@themost/query');
+const { DataAttributeResolver } = require('./data-attribute-resolver');
+const { DataFilterResolver } = require('./data-filter-resolver');
+
+class DataModelFilterParser {
+    /**
+     * 
+     * @param {import("./data-model").DataModel} model 
+     */
+    constructor(model) {
+        this.resolvingMember = new AsyncSeriesEventEmitter();
+        this.resolvingMethod = new AsyncSeriesEventEmitter();
+        this.model = model;
+    }
+    parse(str, callback) {
+        const self = this;
+        const thisModel = this.model;
+        const $expand = [];
+        const parser = new OpenDataParser();
+        parser.resolveMember = function(member, cb) {
+            const attr = thisModel.field(member);
+            if (attr) {
+                member = attr.name;
+                if (attr.multiplicity === 'ZeroOrOne') {
+                    var mapping1 = thisModel.inferMapping(member);
+                    if (mapping1 && mapping1.associationType === 'junction' && mapping1.parentModel === thisModel.name) {
+                        member = attr.name.concat('/', mapping1.childField);
+                    } else if (mapping1 && mapping1.associationType === 'junction' && mapping1.childModel === thisModel.name) {
+                        member = attr.name.concat('/', mapping1.parentField);
+                    }
+                }
+            }
+            const event = {
+                target: self,
+                member: member,
+                result: null
+            }
+            void self.resolvingMember.emit(event).then(() => {
+                if (event.result) {
+                    return cb(null, event.result.$select);
+                }
+                if (DataAttributeResolver.prototype.testNestedAttribute.call(thisModel,member)) {
+                    try {
+                        var member1 = member.split('/'),
+                            mapping = thisModel.inferMapping(member1[0]),
+                            expr;
+                        if (mapping && mapping.associationType === 'junction') {
+                            var expr1 = DataAttributeResolver.prototype.resolveJunctionAttributeJoin.call(thisModel, member);
+                            expr = {
+                                $expand: expr1.$expand
+                            };
+                            //replace member expression
+                            member = expr1.$select.$name.replace(/\./g,'/');
+                        }
+                        else {
+                            expr = DataAttributeResolver.prototype.resolveNestedAttributeJoin.call(thisModel, member);
+                            if (expr.$select) {
+                                member = expr.$select.$name.replace(/\./g,'/');
+                            }
+                        }
+                        if (expr && expr.$expand) {
+                            var arrExpr = [];
+                            if (Array.isArray(expr.$expand)) {
+                                arrExpr.push.apply(arrExpr, expr.$expand);
+                            } else {
+                                arrExpr.push(expr.$expand);
+                            }
+                            arrExpr.forEach(function(y) {
+                                var joinExpr = $expand.find(function(x) {
+                                    if (x.$entity && x.$entity.$as) {
+                                        return (x.$entity.$as === y.$entity.$as);
+                                    }
+                                    return false;
+                                });
+                                if (joinExpr == null)
+                                    $expand.push(y);
+                            });
+                        }
+                    }
+                    catch (err) {
+                        return cb(err);
+                    }
+                }
+                if (typeof thisModel.resolveMember === 'function') {
+                    thisModel.resolveMember.call(thisModel, member, cb);
+                } else {
+                    DataFilterResolver.prototype.resolveMember.call(thisModel, member, cb);
+                }
+            }).catch(function(err) {
+                return callback(err);
+            });
+            
+        }
+
+        parser.resolveMethod = function(name, args, cb) {
+            const thisModel = self.model;
+            const event = {
+                target: self,
+                method: name,
+                args: args,
+                result: null
+            }
+            void self.resolvingMethod.emit(event).then(function() {
+                if (event.result) {
+                    return cb(null, event.result);
+                }
+                if (typeof thisModel.resolveMethod === 'function') {
+                    thisModel.resolveMethod.call(thisModel, name, args, cb);
+                } else {
+                    DataFilterResolver.prototype.resolveMethod.call(thisModel, name, args, cb);
+                }
+            }).catch(function(err) {
+                return cb(err);
+            });
+        }
+
+        void parser.parse(str, function(err, result) {
+            if (err) {
+                return callback(err);
+            }
+            return callback(null, {
+                $where: result,
+                $expand: $expand
+            });
+        });
+    }
+    parseAsync(str) {
+        const self = this;
+        return new Promise(function(resolve, reject) {
+            void self.parse(str, function(err, result) {
+                if (err) {
+                    return reject(err);
+                }
+                return resolve(result);
+            });
+        });
+    }
+}
+
+module.exports = {
+    DataModelFilterParser
+}

--- a/data-permission.d.ts
+++ b/data-permission.d.ts
@@ -1,7 +1,7 @@
 // MOST Web Framework 2.0 Codename Blueshift BSD-3-Clause license Copyright (c) 2017-2022, THEMOST LP All rights reserved
 import {DataModel} from "./data-model";
 import {DataQueryable} from "./data-queryable";
-import {BeforeExecuteEventListener, BeforeRemoveEventListener, BeforeSaveEventListener, DataEventArgs} from "./types";
+import {BeforeExecuteEventListener, BeforeRemoveEventListener, BeforeSaveEventListener, DataEventArgs, DataModelPrivilege} from "./types";
 
 export declare class DataPermissionEventArgs {
     model: DataModel;
@@ -33,4 +33,10 @@ export declare class DataPermissionEventListener implements BeforeSaveEventListe
     beforeExecute(event: DataEventArgs, callback: (err?: Error) => void): void;
 
     validate(event: DataEventArgs, callback: (err?: Error) => void): void;
+}
+
+export declare class DataPermissionExclusion {
+    constructor(model: DataModel);
+    shouldExclude(privilege: DataModelPrivilege, callback: (err?: Error, result?: boolean) => void): void;
+    shouldExcludeAsync(privilege: DataModelPrivilege): Promise<boolean>;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.6.47",
+      "version": "2.6.48",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.3.0",
@@ -53,7 +53,7 @@
       },
       "peerDependencies": {
         "@themost/common": "^2.5.11",
-        "@themost/query": "^2.5.9",
+        "@themost/query": "^2.5.22",
         "@themost/xml": "^2.5.2"
       }
     },
@@ -163,52 +163,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/core/node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core/node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/core/node_modules/@babel/helper-validator-identifier": {
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
@@ -258,27 +212,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/core/node_modules/@babel/traverse": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
-      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.6",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.6",
-        "@babel/types": "^7.23.6",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/core/node_modules/@babel/types": {
       "version": "7.23.6",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
@@ -305,15 +238,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
@@ -402,15 +326,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.17.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.9.tgz",
@@ -484,15 +399,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.4.tgz",
@@ -509,31 +415,6 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/@babel/compat-data": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/@babel/helper-compilation-targets": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/compat-data": "^7.23.5",
-        "@babel/helper-validator-option": "^7.23.5",
-        "browserslist": "^4.22.2",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-define-polyfill-provider/node_modules/@babel/helper-plugin-utils": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
@@ -542,103 +423,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/@babel/helper-validator-option": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/browserslist": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001565",
-        "electron-to-chromium": "^1.4.601",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/caniuse-lite": {
-      "version": "1.0.30001576",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ]
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/electron-to-chromium": {
-      "version": "1.4.625",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-      "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
-      "dev": true
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-      "dev": true
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/helper-define-polyfill-provider/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
     },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.16.7",
@@ -1112,67 +896,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helpers/node_modules/@babel/generator": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
-      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.23.6",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
-        "jsesc": "^2.5.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helpers/node_modules/@babel/helper-validator-identifier": {
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
@@ -1222,27 +945,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helpers/node_modules/@babel/traverse": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
-      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.23.5",
-        "@babel/generator": "^7.23.6",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.6",
-        "@babel/types": "^7.23.6",
-        "debug": "^4.3.1",
-        "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helpers/node_modules/@babel/types": {
       "version": "7.23.6",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
@@ -1255,20 +957,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/highlight": {
@@ -1818,46 +1506,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-async-to-generator/node_modules/@babel/helper-module-imports": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.15"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-async-to-generator/node_modules/@babel/helper-plugin-utils": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
       "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-async-to-generator/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-async-to-generator/node_modules/@babel/types": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2121,15 +1774,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/plugin-transform-class-properties/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/plugin-transform-class-static-block": {
       "version": "7.23.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.23.4.tgz",
@@ -2342,15 +1986,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/plugin-transform-class-static-block/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/plugin-transform-classes": {
       "version": "7.23.8",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.8.tgz",
@@ -2386,15 +2021,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/plugin-transform-classes/node_modules/@babel/compat-data": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-classes/node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
@@ -2402,22 +2028,6 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-classes/node_modules/@babel/helper-compilation-targets": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/compat-data": "^7.23.5",
-        "@babel/helper-validator-option": "^7.23.5",
-        "browserslist": "^4.22.2",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2516,15 +2126,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/plugin-transform-classes/node_modules/@babel/helper-validator-option": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-classes/node_modules/@babel/highlight": {
       "version": "7.23.4",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
@@ -2578,94 +2179,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/plugin-transform-classes/node_modules/browserslist": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001565",
-        "electron-to-chromium": "^1.4.601",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/@babel/plugin-transform-classes/node_modules/caniuse-lite": {
-      "version": "1.0.30001576",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ]
-    },
-    "node_modules/@babel/plugin-transform-classes/node_modules/electron-to-chromium": {
-      "version": "1.4.625",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-      "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
-      "dev": true
-    },
-    "node_modules/@babel/plugin-transform-classes/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/@babel/plugin-transform-classes/node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-      "dev": true
-    },
-    "node_modules/@babel/plugin-transform-classes/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/plugin-transform-classes/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
       "version": "7.23.3",
@@ -2971,31 +2484,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/plugin-transform-function-name/node_modules/@babel/compat-data": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-function-name/node_modules/@babel/helper-compilation-targets": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/compat-data": "^7.23.5",
-        "@babel/helper-validator-option": "^7.23.5",
-        "browserslist": "^4.22.2",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-function-name/node_modules/@babel/helper-function-name": {
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
@@ -3022,15 +2510,6 @@
       "version": "7.22.20",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
       "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-function-name/node_modules/@babel/helper-validator-option": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -3089,94 +2568,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/plugin-transform-function-name/node_modules/browserslist": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001565",
-        "electron-to-chromium": "^1.4.601",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/@babel/plugin-transform-function-name/node_modules/caniuse-lite": {
-      "version": "1.0.30001576",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ]
-    },
-    "node_modules/@babel/plugin-transform-function-name/node_modules/electron-to-chromium": {
-      "version": "1.4.625",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-      "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
-      "dev": true
-    },
-    "node_modules/@babel/plugin-transform-function-name/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/@babel/plugin-transform-function-name/node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-      "dev": true
-    },
-    "node_modules/@babel/plugin-transform-function-name/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/plugin-transform-function-name/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
     },
     "node_modules/@babel/plugin-transform-json-strings": {
       "version": "7.23.4",
@@ -3292,98 +2683,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-modules-amd/node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-amd/node_modules/@babel/helper-module-imports": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.15"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-amd/node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.20"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-modules-amd/node_modules/@babel/helper-plugin-utils": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
       "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-amd/node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-amd/node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-amd/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-amd/node_modules/@babel/types": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3405,98 +2709,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-modules-commonjs/node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-commonjs/node_modules/@babel/helper-module-imports": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.15"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-commonjs/node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.20"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-modules-commonjs/node_modules/@babel/helper-plugin-utils": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
       "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-commonjs/node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-commonjs/node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-commonjs/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-commonjs/node_modules/@babel/types": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3519,15 +2736,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-modules-systemjs/node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-modules-systemjs/node_modules/@babel/helper-hoist-variables": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
@@ -3540,66 +2748,11 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/plugin-transform-modules-systemjs/node_modules/@babel/helper-module-imports": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.15"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-systemjs/node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.20"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-modules-systemjs/node_modules/@babel/helper-plugin-utils": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
       "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-systemjs/node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-systemjs/node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3643,98 +2796,11 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-modules-umd/node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-umd/node_modules/@babel/helper-module-imports": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-      "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.15"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-umd/node_modules/@babel/helper-module-transforms": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-      "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-module-imports": "^7.22.15",
-        "@babel/helper-simple-access": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/helper-validator-identifier": "^7.22.20"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-modules-umd/node_modules/@babel/helper-plugin-utils": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
       "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-umd/node_modules/@babel/helper-simple-access": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-      "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-umd/node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-umd/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-umd/node_modules/@babel/types": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.23.4",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -3857,31 +2923,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-object-rest-spread/node_modules/@babel/compat-data": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-object-rest-spread/node_modules/@babel/helper-compilation-targets": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/compat-data": "^7.23.5",
-        "@babel/helper-validator-option": "^7.23.5",
-        "browserslist": "^4.22.2",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-object-rest-spread/node_modules/@babel/helper-plugin-utils": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
@@ -3890,103 +2931,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/plugin-transform-object-rest-spread/node_modules/@babel/helper-validator-option": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-object-rest-spread/node_modules/browserslist": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001565",
-        "electron-to-chromium": "^1.4.601",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/@babel/plugin-transform-object-rest-spread/node_modules/caniuse-lite": {
-      "version": "1.0.30001576",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ]
-    },
-    "node_modules/@babel/plugin-transform-object-rest-spread/node_modules/electron-to-chromium": {
-      "version": "1.4.625",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-      "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
-      "dev": true
-    },
-    "node_modules/@babel/plugin-transform-object-rest-spread/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/@babel/plugin-transform-object-rest-spread/node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-      "dev": true
-    },
-    "node_modules/@babel/plugin-transform-object-rest-spread/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/plugin-transform-object-rest-spread/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
     },
     "node_modules/@babel/plugin-transform-object-super": {
       "version": "7.23.3",
@@ -4372,15 +3316,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/plugin-transform-private-methods/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
       "version": "7.23.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.23.4.tgz",
@@ -4592,15 +3527,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-private-property-in-object/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
@@ -5007,31 +3933,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/preset-env/node_modules/@babel/compat-data": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/preset-env/node_modules/@babel/helper-compilation-targets": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-      "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/compat-data": "^7.23.5",
-        "@babel/helper-validator-option": "^7.23.5",
-        "browserslist": "^4.22.2",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/preset-env/node_modules/@babel/helper-plugin-utils": {
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
@@ -5049,94 +3950,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/preset-env/node_modules/browserslist": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001565",
-        "electron-to-chromium": "^1.4.601",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/@babel/preset-env/node_modules/caniuse-lite": {
-      "version": "1.0.30001576",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ]
-    },
-    "node_modules/@babel/preset-env/node_modules/electron-to-chromium": {
-      "version": "1.4.625",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-      "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
-      "dev": true
-    },
-    "node_modules/@babel/preset-env/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/@babel/preset-env/node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-      "dev": true
-    },
-    "node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@babel/preset-env/node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
     },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
@@ -6982,24 +5795,6 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
-    "node_modules/babel-plugin-polyfill-corejs2/node_modules/@babel/compat-data": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-      "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.7.tgz",
@@ -7127,12 +5922,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -7455,70 +6250,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
-    },
-    "node_modules/core-js-compat/node_modules/browserslist": {
-      "version": "4.22.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-      "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001565",
-        "electron-to-chromium": "^1.4.601",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/core-js-compat/node_modules/caniuse-lite": {
-      "version": "1.0.30001576",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ]
-    },
-    "node_modules/core-js-compat/node_modules/electron-to-chromium": {
-      "version": "1.4.625",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-      "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
-      "dev": true
-    },
-    "node_modules/core-js-compat/node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-      "dev": true
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -8492,9 +7223,9 @@
       "dev": true
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -8920,12 +7651,19 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
-    "node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -11340,6 +10078,13 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -12702,17 +11447,17 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
       "optional": true,
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
@@ -12751,9 +11496,9 @@
       }
     },
     "node_modules/sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/sql.js": {
       "version": "1.6.2",
@@ -12927,9 +11672,9 @@
       "integrity": "sha1-tvmpANSWpX8CQI8iGYwQndoGMEE="
     },
     "node_modules/tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -13528,40 +12273,6 @@
             "jsesc": "^2.5.1"
           }
         },
-        "@babel/helper-environment-visitor": {
-          "version": "7.22.20",
-          "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-          "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-          "dev": true
-        },
-        "@babel/helper-function-name": {
-          "version": "7.23.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-          "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-          "dev": true,
-          "requires": {
-            "@babel/template": "^7.22.15",
-            "@babel/types": "^7.23.0"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.22.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-          "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.5"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.22.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-          "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.5"
-          }
-        },
         "@babel/helper-validator-identifier": {
           "version": "7.22.20",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
@@ -13596,24 +12307,6 @@
             "@babel/types": "^7.22.15"
           }
         },
-        "@babel/traverse": {
-          "version": "7.23.7",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
-          "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.23.5",
-            "@babel/generator": "^7.23.6",
-            "@babel/helper-environment-visitor": "^7.22.20",
-            "@babel/helper-function-name": "^7.23.0",
-            "@babel/helper-hoist-variables": "^7.22.5",
-            "@babel/helper-split-export-declaration": "^7.22.6",
-            "@babel/parser": "^7.23.6",
-            "@babel/types": "^7.23.6",
-            "debug": "^4.3.1",
-            "globals": "^11.1.0"
-          }
-        },
         "@babel/types": {
           "version": "7.23.6",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
@@ -13635,12 +12328,6 @@
             "@jridgewell/sourcemap-codec": "^1.4.10",
             "@jridgewell/trace-mapping": "^0.3.9"
           }
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
         }
       }
     },
@@ -13710,12 +12397,6 @@
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
           "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
           "dev": true
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
         }
       }
     },
@@ -13770,12 +12451,6 @@
             "@babel/helper-validator-identifier": "^7.22.20",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
         }
       }
     },
@@ -13792,86 +12467,10 @@
         "resolve": "^1.14.2"
       },
       "dependencies": {
-        "@babel/compat-data": {
-          "version": "7.23.5",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-          "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
-          "dev": true
-        },
-        "@babel/helper-compilation-targets": {
-          "version": "7.23.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-          "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
-          "dev": true,
-          "requires": {
-            "@babel/compat-data": "^7.23.5",
-            "@babel/helper-validator-option": "^7.23.5",
-            "browserslist": "^4.22.2",
-            "lru-cache": "^5.1.1",
-            "semver": "^6.3.1"
-          }
-        },
         "@babel/helper-plugin-utils": {
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
           "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
-          "dev": true
-        },
-        "@babel/helper-validator-option": {
-          "version": "7.23.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-          "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
-          "dev": true
-        },
-        "browserslist": {
-          "version": "4.22.2",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-          "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001565",
-            "electron-to-chromium": "^1.4.601",
-            "node-releases": "^2.0.14",
-            "update-browserslist-db": "^1.0.13"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001576",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-          "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.4.625",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-          "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "node-releases": {
-          "version": "2.0.14",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-          "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
         }
       }
@@ -14234,52 +12833,6 @@
             "chalk": "^2.4.2"
           }
         },
-        "@babel/generator": {
-          "version": "7.23.6",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
-          "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.23.6",
-            "@jridgewell/gen-mapping": "^0.3.2",
-            "@jridgewell/trace-mapping": "^0.3.17",
-            "jsesc": "^2.5.1"
-          }
-        },
-        "@babel/helper-environment-visitor": {
-          "version": "7.22.20",
-          "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-          "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-          "dev": true
-        },
-        "@babel/helper-function-name": {
-          "version": "7.23.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-          "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-          "dev": true,
-          "requires": {
-            "@babel/template": "^7.22.15",
-            "@babel/types": "^7.23.0"
-          }
-        },
-        "@babel/helper-hoist-variables": {
-          "version": "7.22.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-          "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.5"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.22.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-          "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.5"
-          }
-        },
         "@babel/helper-validator-identifier": {
           "version": "7.22.20",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
@@ -14314,24 +12867,6 @@
             "@babel/types": "^7.22.15"
           }
         },
-        "@babel/traverse": {
-          "version": "7.23.7",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
-          "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.23.5",
-            "@babel/generator": "^7.23.6",
-            "@babel/helper-environment-visitor": "^7.22.20",
-            "@babel/helper-function-name": "^7.23.0",
-            "@babel/helper-hoist-variables": "^7.22.5",
-            "@babel/helper-split-export-declaration": "^7.22.6",
-            "@babel/parser": "^7.23.6",
-            "@babel/types": "^7.23.6",
-            "debug": "^4.3.1",
-            "globals": "^11.1.0"
-          }
-        },
         "@babel/types": {
           "version": "7.23.6",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
@@ -14341,17 +12876,6 @@
             "@babel/helper-string-parser": "^7.23.4",
             "@babel/helper-validator-identifier": "^7.22.20",
             "to-fast-properties": "^2.0.0"
-          }
-        },
-        "@jridgewell/gen-mapping": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-          "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/set-array": "^1.0.1",
-            "@jridgewell/sourcemap-codec": "^1.4.10",
-            "@jridgewell/trace-mapping": "^0.3.9"
           }
         }
       }
@@ -14739,37 +13263,11 @@
         "@babel/helper-remap-async-to-generator": "^7.22.20"
       },
       "dependencies": {
-        "@babel/helper-module-imports": {
-          "version": "7.22.15",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-          "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.15"
-          }
-        },
         "@babel/helper-plugin-utils": {
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
           "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
           "dev": true
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.22.20",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-          "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.23.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-          "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-string-parser": "^7.23.4",
-            "@babel/helper-validator-identifier": "^7.22.20",
-            "to-fast-properties": "^2.0.0"
-          }
         }
       }
     },
@@ -14957,12 +13455,6 @@
             "@babel/helper-validator-identifier": "^7.22.20",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
         }
       }
     },
@@ -15117,12 +13609,6 @@
             "@babel/helper-validator-identifier": "^7.22.20",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
         }
       }
     },
@@ -15152,12 +13638,6 @@
             "chalk": "^2.4.2"
           }
         },
-        "@babel/compat-data": {
-          "version": "7.23.5",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-          "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
-          "dev": true
-        },
         "@babel/helper-annotate-as-pure": {
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
@@ -15165,19 +13645,6 @@
           "dev": true,
           "requires": {
             "@babel/types": "^7.22.5"
-          }
-        },
-        "@babel/helper-compilation-targets": {
-          "version": "7.23.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-          "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
-          "dev": true,
-          "requires": {
-            "@babel/compat-data": "^7.23.5",
-            "@babel/helper-validator-option": "^7.23.5",
-            "browserslist": "^4.22.2",
-            "lru-cache": "^5.1.1",
-            "semver": "^6.3.1"
           }
         },
         "@babel/helper-environment-visitor": {
@@ -15246,12 +13713,6 @@
           "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
           "dev": true
         },
-        "@babel/helper-validator-option": {
-          "version": "7.23.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-          "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
-          "dev": true
-        },
         "@babel/highlight": {
           "version": "7.23.4",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
@@ -15290,57 +13751,6 @@
             "@babel/helper-validator-identifier": "^7.22.20",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "browserslist": {
-          "version": "4.22.2",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-          "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001565",
-            "electron-to-chromium": "^1.4.601",
-            "node-releases": "^2.0.14",
-            "update-browserslist-db": "^1.0.13"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001576",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-          "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.4.625",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-          "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "node-releases": {
-          "version": "2.0.14",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-          "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
         }
       }
     },
@@ -15562,25 +13972,6 @@
             "chalk": "^2.4.2"
           }
         },
-        "@babel/compat-data": {
-          "version": "7.23.5",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-          "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
-          "dev": true
-        },
-        "@babel/helper-compilation-targets": {
-          "version": "7.23.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-          "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
-          "dev": true,
-          "requires": {
-            "@babel/compat-data": "^7.23.5",
-            "@babel/helper-validator-option": "^7.23.5",
-            "browserslist": "^4.22.2",
-            "lru-cache": "^5.1.1",
-            "semver": "^6.3.1"
-          }
-        },
         "@babel/helper-function-name": {
           "version": "7.23.0",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
@@ -15601,12 +13992,6 @@
           "version": "7.22.20",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
           "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-          "dev": true
-        },
-        "@babel/helper-validator-option": {
-          "version": "7.23.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-          "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
           "dev": true
         },
         "@babel/highlight": {
@@ -15647,57 +14032,6 @@
             "@babel/helper-validator-identifier": "^7.22.20",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "browserslist": {
-          "version": "4.22.2",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-          "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001565",
-            "electron-to-chromium": "^1.4.601",
-            "node-releases": "^2.0.14",
-            "update-browserslist-db": "^1.0.13"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001576",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-          "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.4.625",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-          "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "node-releases": {
-          "version": "2.0.14",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-          "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
         }
       }
     },
@@ -15781,74 +14115,11 @@
         "@babel/helper-plugin-utils": "^7.22.5"
       },
       "dependencies": {
-        "@babel/helper-environment-visitor": {
-          "version": "7.22.20",
-          "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-          "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-          "dev": true
-        },
-        "@babel/helper-module-imports": {
-          "version": "7.22.15",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-          "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.15"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.23.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-          "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-environment-visitor": "^7.22.20",
-            "@babel/helper-module-imports": "^7.22.15",
-            "@babel/helper-simple-access": "^7.22.5",
-            "@babel/helper-split-export-declaration": "^7.22.6",
-            "@babel/helper-validator-identifier": "^7.22.20"
-          }
-        },
         "@babel/helper-plugin-utils": {
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
           "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
           "dev": true
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.22.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-          "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.5"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.22.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-          "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.5"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.22.20",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-          "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.23.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-          "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-string-parser": "^7.23.4",
-            "@babel/helper-validator-identifier": "^7.22.20",
-            "to-fast-properties": "^2.0.0"
-          }
         }
       }
     },
@@ -15863,74 +14134,11 @@
         "@babel/helper-simple-access": "^7.22.5"
       },
       "dependencies": {
-        "@babel/helper-environment-visitor": {
-          "version": "7.22.20",
-          "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-          "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-          "dev": true
-        },
-        "@babel/helper-module-imports": {
-          "version": "7.22.15",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-          "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.15"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.23.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-          "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-environment-visitor": "^7.22.20",
-            "@babel/helper-module-imports": "^7.22.15",
-            "@babel/helper-simple-access": "^7.22.5",
-            "@babel/helper-split-export-declaration": "^7.22.6",
-            "@babel/helper-validator-identifier": "^7.22.20"
-          }
-        },
         "@babel/helper-plugin-utils": {
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
           "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
           "dev": true
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.22.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-          "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.5"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.22.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-          "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.5"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.22.20",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-          "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.23.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-          "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-string-parser": "^7.23.4",
-            "@babel/helper-validator-identifier": "^7.22.20",
-            "to-fast-properties": "^2.0.0"
-          }
         }
       }
     },
@@ -15946,12 +14154,6 @@
         "@babel/helper-validator-identifier": "^7.22.20"
       },
       "dependencies": {
-        "@babel/helper-environment-visitor": {
-          "version": "7.22.20",
-          "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-          "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-          "dev": true
-        },
         "@babel/helper-hoist-variables": {
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
@@ -15961,51 +14163,11 @@
             "@babel/types": "^7.22.5"
           }
         },
-        "@babel/helper-module-imports": {
-          "version": "7.22.15",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-          "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.15"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.23.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-          "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-environment-visitor": "^7.22.20",
-            "@babel/helper-module-imports": "^7.22.15",
-            "@babel/helper-simple-access": "^7.22.5",
-            "@babel/helper-split-export-declaration": "^7.22.6",
-            "@babel/helper-validator-identifier": "^7.22.20"
-          }
-        },
         "@babel/helper-plugin-utils": {
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
           "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
           "dev": true
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.22.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-          "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.5"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.22.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-          "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.5"
-          }
         },
         "@babel/helper-validator-identifier": {
           "version": "7.22.20",
@@ -16036,74 +14198,11 @@
         "@babel/helper-plugin-utils": "^7.22.5"
       },
       "dependencies": {
-        "@babel/helper-environment-visitor": {
-          "version": "7.22.20",
-          "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-          "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-          "dev": true
-        },
-        "@babel/helper-module-imports": {
-          "version": "7.22.15",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
-          "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.15"
-          }
-        },
-        "@babel/helper-module-transforms": {
-          "version": "7.23.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
-          "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-environment-visitor": "^7.22.20",
-            "@babel/helper-module-imports": "^7.22.15",
-            "@babel/helper-simple-access": "^7.22.5",
-            "@babel/helper-split-export-declaration": "^7.22.6",
-            "@babel/helper-validator-identifier": "^7.22.20"
-          }
-        },
         "@babel/helper-plugin-utils": {
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
           "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
           "dev": true
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.22.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-          "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.5"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.22.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-          "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.22.5"
-          }
-        },
-        "@babel/helper-validator-identifier": {
-          "version": "7.22.20",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-          "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.23.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-          "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-string-parser": "^7.23.4",
-            "@babel/helper-validator-identifier": "^7.22.20",
-            "to-fast-properties": "^2.0.0"
-          }
         }
       }
     },
@@ -16191,86 +14290,10 @@
         "@babel/plugin-transform-parameters": "^7.23.3"
       },
       "dependencies": {
-        "@babel/compat-data": {
-          "version": "7.23.5",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-          "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
-          "dev": true
-        },
-        "@babel/helper-compilation-targets": {
-          "version": "7.23.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-          "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
-          "dev": true,
-          "requires": {
-            "@babel/compat-data": "^7.23.5",
-            "@babel/helper-validator-option": "^7.23.5",
-            "browserslist": "^4.22.2",
-            "lru-cache": "^5.1.1",
-            "semver": "^6.3.1"
-          }
-        },
         "@babel/helper-plugin-utils": {
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
           "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
-          "dev": true
-        },
-        "@babel/helper-validator-option": {
-          "version": "7.23.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-          "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
-          "dev": true
-        },
-        "browserslist": {
-          "version": "4.22.2",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-          "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001565",
-            "electron-to-chromium": "^1.4.601",
-            "node-releases": "^2.0.14",
-            "update-browserslist-db": "^1.0.13"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001576",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-          "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.4.625",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-          "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "node-releases": {
-          "version": "2.0.14",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-          "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
         }
       }
@@ -16549,12 +14572,6 @@
             "@babel/helper-validator-identifier": "^7.22.20",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
         }
       }
     },
@@ -16710,12 +14727,6 @@
             "@babel/helper-validator-identifier": "^7.22.20",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
         }
       }
     },
@@ -17027,25 +15038,6 @@
         "semver": "^6.3.1"
       },
       "dependencies": {
-        "@babel/compat-data": {
-          "version": "7.23.5",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-          "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
-          "dev": true
-        },
-        "@babel/helper-compilation-targets": {
-          "version": "7.23.6",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
-          "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
-          "dev": true,
-          "requires": {
-            "@babel/compat-data": "^7.23.5",
-            "@babel/helper-validator-option": "^7.23.5",
-            "browserslist": "^4.22.2",
-            "lru-cache": "^5.1.1",
-            "semver": "^6.3.1"
-          }
-        },
         "@babel/helper-plugin-utils": {
           "version": "7.22.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
@@ -17056,57 +15048,6 @@
           "version": "7.23.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
           "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
-          "dev": true
-        },
-        "browserslist": {
-          "version": "4.22.2",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-          "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001565",
-            "electron-to-chromium": "^1.4.601",
-            "node-releases": "^2.0.14",
-            "update-browserslist-db": "^1.0.13"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001576",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-          "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.4.625",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-          "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "node-releases": {
-          "version": "2.0.14",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-          "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
         }
       }
@@ -18585,20 +16526,6 @@
         "@babel/compat-data": "^7.22.6",
         "@babel/helper-define-polyfill-provider": "^0.4.4",
         "semver": "^6.3.1"
-      },
-      "dependencies": {
-        "@babel/compat-data": {
-          "version": "7.23.5",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
-          "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-          "dev": true
-        }
       }
     },
     "babel-plugin-polyfill-corejs3": {
@@ -18699,12 +16626,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browserslist": {
@@ -18927,38 +16854,6 @@
       "dev": true,
       "requires": {
         "browserslist": "^4.22.2"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "4.22.2",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
-          "integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001565",
-            "electron-to-chromium": "^1.4.601",
-            "node-releases": "^2.0.14",
-            "update-browserslist-db": "^1.0.13"
-          }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001576",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-          "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.4.625",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-          "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
-          "dev": true
-        },
-        "node-releases": {
-          "version": "2.0.14",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-          "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-          "dev": true
-        }
       }
     },
     "create-jest": {
@@ -19673,9 +17568,9 @@
       "dev": true
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -19993,12 +17888,16 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
-    "ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+    "ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      }
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -21815,6 +19714,13 @@
         "argparse": "^2.0.1"
       }
     },
+    "jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "dev": true,
+      "optional": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -22832,13 +20738,13 @@
       "optional": true
     },
     "socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dev": true,
       "optional": true,
       "requires": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       }
     },
@@ -22871,9 +20777,9 @@
       }
     },
     "sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "sql.js": {
       "version": "1.6.2",
@@ -22999,9 +20905,9 @@
       "integrity": "sha1-tvmpANSWpX8CQI8iGYwQndoGMEE="
     },
     "tar": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
-      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "dev": true,
       "requires": {
         "chownr": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.6.48",
+  "version": "2.6.49",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.6.48",
+      "version": "2.6.49",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.48",
+  "version": "2.6.49",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "types": "index.d.ts",

--- a/spec/DataPrivilege.exclude.spec.ts
+++ b/spec/DataPrivilege.exclude.spec.ts
@@ -1,0 +1,270 @@
+import {TestUtils} from './adapter/TestUtils';
+import { TestApplication } from './TestApplication';
+import { DataContext } from '../types';
+import {DataModelFilterParser} from '../data-model-filter.parser';
+import { at } from 'lodash';
+import { DataPermissionExclusion } from '../data-permission';
+import { DataConfigurationStrategy } from '../data-configuration';
+import { resolve } from 'path';
+import { cloneDeep } from 'lodash';
+
+describe('DataPrivilege', () => {
+
+    let app: TestApplication;
+    let context: DataContext;
+    beforeAll((done) => {
+        app = new TestApplication(resolve(__dirname, 'test2'));
+        // set default adapter
+        app.getConfiguration().setSourceAt('adapters', [
+            {
+                name: 'test-local',
+                invariantName: 'test',
+                default: true,
+                options: {
+                    database: resolve(__dirname, 'test2/db/local.db')
+                }
+            }
+        ])
+        context = app.createContext();
+        return done();
+    });
+    afterAll(async () => {
+        await context.finalize();
+        await app.finalize();
+    });
+
+    it('should validate exclude expression', async () => {
+        const Users = context.model('User');
+        Object.assign(context, {
+            user: {
+                name: 'luis.nash@example.com',
+                authenticationScope: 'profile'
+            }
+        })
+        const queryUsers = Users.asQueryable();
+        const parser = new DataModelFilterParser(Users);
+        const addSelect: any[] = [
+            {
+                "name": {
+                    $value: (context as any).user.name
+                }
+            }
+        ];
+        parser.resolvingMember.subscribe(async (event) => {
+            const propertyPath = event.member.split('/');
+            if (propertyPath[0] === 'context') {
+                propertyPath.splice(0, 1);
+                const property = at(context as any, propertyPath.join('.'))[0];
+                const propertyName = propertyPath[propertyPath.length - 1];
+                const exists = addSelect.findIndex((item) => Object.prototype.hasOwnProperty.call(item, propertyPath));
+                if (exists < 0) {
+                    const select = {};
+                    Object.defineProperty(select, propertyName , {
+                        enumerable: true,
+                        configurable: true,
+                        value: {
+                            $value: property
+                        }
+                    });
+                    addSelect.push(select);
+                }
+                event.result = {
+                    $select: propertyName
+                }
+            }
+        });
+        let q1 = await parser.parseAsync('context/user/authenticationScope eq \'profile\' or context/user/authenticationScope eq \'email\'');
+        expect(q1).toBeTruthy();
+        queryUsers.query.select([].concat(addSelect));
+        Object.assign(queryUsers.query, {
+            $where: q1.$where,
+            $expand: q1.$expand,
+            // $fixed: true
+        });
+        let result: any[] = await (context.db as any).executeAsync(queryUsers.query);
+        expect(result.length).toBeTruthy();
+
+        q1 = await parser.parseAsync('indexof(context/user/authenticationScope, \'profile\') eq 0');
+        expect(q1).toBeTruthy();
+        queryUsers.query.select([].concat(addSelect));
+        Object.assign(queryUsers.query, {
+            $where: q1.$where,
+            $expand: q1.$expand,
+            // $fixed: true
+        });
+        result = await (context.db as any).executeAsync(queryUsers.query);
+        expect(result.length).toBeTruthy();
+    });
+    it('should use permission exclusion', async () => {
+        Object.assign(context, {
+            user: {
+                name: 'luis.nash@example.com',
+                authenticationScope: 'profile'
+            }
+        });
+        const exclusion = new DataPermissionExclusion(context.model('Orders'));
+        const result = await exclusion.shouldExcludeAsync({
+            mask: 15,
+            type: 'self',
+            account: 'Employees',
+            exclude: 'indexof(context/user/authenticationScope, \'sales\') lt 0'
+        });
+        expect(result).toBeTruthy();
+    });
+
+    it('should use context scope', async () => {
+        Object.assign(context, {
+            user: {
+                name: 'luis.nash@example.com',
+                authenticationScope: 'profile,email'
+            }
+        });
+        let items = await context.model('Order').where('customer/email').equal('luis.nash@example.com').getItems();
+        expect(items.length).toBeTruthy();
+        const model = app.getConfiguration().getStrategy(DataConfigurationStrategy).getModelDefinition('Order');
+        const originalModel = cloneDeep(model);
+        const privilege = model.privileges.find((item: any) => item.type === 'self' && item.filter === 'customer/user eq me()');
+        expect(privilege).toBeTruthy();
+        privilege.scope = [
+            'orders'
+        ];
+        app.getConfiguration().getStrategy(DataConfigurationStrategy).setModelDefinition(model);
+        items = await context.model('Order').where('customer/email').equal('luis.nash@example.com').getItems();
+        expect(items.length).toBeFalsy();
+        // new scope
+        Object.assign(context, {
+            user: {
+                name: 'luis.nash@example.com',
+                authenticationScope: 'profile email orders'
+            }
+        });
+        items = await context.model('Order').where('customer/email').equal('luis.nash@example.com').getItems();
+        expect(items.length).toBeTruthy();
+        // restore model
+        app.getConfiguration().getStrategy(DataConfigurationStrategy).setModelDefinition(originalModel);
+    });
+
+
+    it('should validate context scope on insert', async () => {
+        await TestUtils.executeInTransaction(context, async () => {
+            Object.assign(context, {
+                user: {
+                    name: 'luis.nash@example.com',
+                    authenticationScope: 'profile email'
+                }
+            });
+            const customer = await context.model('Person').where('user/name').equal('luis.nash@example.com').getItem();
+            expect(customer).toBeTruthy();
+            // update privileges
+            const model = app.getConfiguration().getStrategy(DataConfigurationStrategy).getModelDefinition('Order');
+            const originalModel = cloneDeep(model);
+            const index = model.privileges.findIndex((item: any) => {
+                return item.type === 'self' && item.filter === 'customer/user eq me() and orderStatus/alternateName eq \'OrderProcessing\'';
+            });
+            if (index >= 0) {
+                model.privileges.splice(index, 1);
+            }
+            model.privileges.push({
+                type: 'self',
+                mask: 14,
+                filter: 'customer/user eq me() and orderStatus/alternateName eq \'OrderProcessing\'',
+                scope: [
+                    'orders'
+                ]
+            });
+            app.getConfiguration().getStrategy(DataConfigurationStrategy).setModelDefinition(model);
+            // try to create order
+            const orderStatus = {
+                alternateName: 'OrderProcessing'
+            };
+            const orderedItem = await context.model('Product').where('category').equal('Laptops').orderBy('price').getItem();
+            expect(orderedItem).toBeTruthy();
+            let newOrder = {
+                orderStatus,
+                orderedItem,
+                customer
+            }
+            await expect(context.model('Order').save(newOrder)).rejects.toThrowError('Access Denied');
+            // add scope
+            Object.assign(context, {
+                user: {
+                    name: 'luis.nash@example.com',
+                    authenticationScope: 'profile email orders'
+                }
+            });
+            newOrder = {
+                orderStatus,
+                orderedItem,
+                customer
+            }
+            await expect(context.model('Order').save(newOrder)).resolves.toBeTruthy();
+            // restore model
+            app.getConfiguration().getStrategy(DataConfigurationStrategy).setModelDefinition(originalModel);
+        });
+    });
+
+
+    it('should validate empty privileges', async () => {
+        await TestUtils.executeInTransaction(context, async () => {
+            Object.assign(context, {
+                user: {
+                    name: 'luis.nash@example.com',
+                    authenticationScope: 'profile email'
+                }
+            });
+            const newValue = {
+                name: 'test',
+                alternateName: 'test',
+                description: 'test'
+            };
+            const Values = context.model('AnotherStructuredValue');
+            expect(Values.privileges.length).toBeFalsy();
+            await expect(Values.save(newValue)).rejects.toThrowError('Access Denied');
+        });
+    });
+
+    it('should validate empty privileges after exclusion', async () => {
+        await TestUtils.executeInTransaction(context, async () => {
+            Object.assign(context, {
+                user: {
+                    name: 'luis.nash@example.com',
+                    authenticationScope: 'profile email'
+                }
+            });
+            let newValue = {
+                name: 'test',
+                alternateName: 'test',
+                description: 'test'
+            };
+            const model = app.getConfiguration().getStrategy(DataConfigurationStrategy).getModelDefinition('AnotherStructuredValue');
+            const originalModel = cloneDeep(model);
+            model.privileges.push({
+                type: 'self',
+                mask: 15,
+                filter: 'alternateName eq \'test\'',
+                scope: [
+                    'test'
+                ]
+            });
+            app.getConfiguration().getStrategy(DataConfigurationStrategy).setModelDefinition(model);
+            const Values = context.model('AnotherStructuredValue');
+            expect(Values.privileges.length).toBeTruthy();
+            await expect(Values.save(newValue)).rejects.toThrowError('Access Denied');
+            Object.assign(context, {
+                user: {
+                    name: 'luis.nash@example.com',
+                    authenticationScope: 'profile email test'
+                }
+            });
+            newValue = {
+                name: 'test',
+                alternateName: 'test',
+                description: 'test'
+            };
+            await expect(Values.save(newValue)).resolves.toBeTruthy();
+            app.getConfiguration().getStrategy(DataConfigurationStrategy).setModelDefinition(originalModel);
+        });
+    });
+
+
+});

--- a/spec/test2/config/models/AnotherStructuredValue.json
+++ b/spec/test2/config/models/AnotherStructuredValue.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://themost-framework.github.io/themost/models/2018/2/schema.json",
+    "@id": "http://schema.org/AnotherStructuredValue",
+    "name": "AnotherStructuredValue",
+    "description": "Structured values are used when the value of a property has a more complex structure than simply being a textual value or a reference to another thing.",
+    "title": "AnotherStructuredValue",
+    "abstract": false,
+    "sealed": false,
+    "inherits": "Intangible",
+    "version": "2.0",
+    "fields": [],
+    "privileges": [
+    ]
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -87,6 +87,8 @@ export declare interface DataModelPrivilege {
     mask: number;
     account?: string;
     filter?: string;
+    scope?: string[];
+    exclude?: string;
 }
 
 export declare class DataAssociationMapping {


### PR DESCRIPTION
This PR implements the exclusion of one or more privileges according to authentication scopes included in user context e.g. A customer should add an order when they have `orders` scope. This operation is being represented by a privilege like the following:
```json
{
    "type": "self",
    "mask": 14,
    "filter": "customer/user eq me() and orderStatus/alternateName eq 'OrderProcessing'",
    "scope": [
        "orders"
    ]
}
```
where a customer is able to create, update or delete their own order with status equal to `OrderProcessing` when they have `orders` scope.
