### PR TITLE
implement when condition

### DIFF
--- a/data-object-tag.d.ts
+++ b/data-object-tag.d.ts
@@ -5,6 +5,7 @@ import {DataModel} from "./data-model";
 import {DataObject} from "./data-object";
 
 export declare class DataObjectTag extends DataQueryable {
+    constructor(target: any, association: DataAssociationMapping | string);
     parent: DataObject;
     mapping: DataAssociationMapping;
     getBaseModel(): DataModel;
@@ -13,5 +14,5 @@ export declare class DataObjectTag extends DataQueryable {
     insert(obj: any): Promise<any>;
     remove(obj: any): Promise<any>;
     removeAll(): Promise<any>;
-    migrate(callback: (err?: Error) => void);
+    migrate(callback: (err?: Error) => void): void;
 }

--- a/data-object.d.ts
+++ b/data-object.d.ts
@@ -17,6 +17,7 @@ export declare class DataObject extends SequentialEventEmitter {
     getModel(): DataModel;
     getAdditionalModel():Promise<DataModel>;
     getAdditionalObject():Promise<DataObject|any>;
-    attr(name: string, callback?:(err?: Error,res?: any) => void);
-    property(name: string);
+    attr(name: string, callback?:(err?: Error,res?: any) => void): void;
+    attr(name: string): any;
+    property(name: string): any;
 }

--- a/data-ref-object-listener.js
+++ b/data-ref-object-listener.js
@@ -5,6 +5,7 @@ var {DataObjectJunction} = require('./data-object-junction');
 var {DataError} = require('@themost/common');
 var _ = require('lodash');
 var {hasOwnProperty} = require('./has-own-property');
+var {DataObjectTag} = require('./data-object-tag');
 
 /**
  * @class
@@ -173,7 +174,7 @@ function beforeRemoveChildConnectedObjects(event, mapping, callback) {
         target = event.model.convert(event.target),
         parentModel =  event.model,
         parentField = parentModel.getAttribute(mapping.parentField);
-    var junction = new HasParentJunction(target, mapping);
+    var junction= childModel == null ? new DataObjectTag(target, mapping) : new HasParentJunction(target, mapping);
     return parentModel.where(parentModel.primaryKey).equal(target.getId())
         .select(parentField.name)
         .cache(false)

--- a/has-parent-junction.d.ts
+++ b/has-parent-junction.d.ts
@@ -5,6 +5,7 @@ import {DataAssociationMapping, DataField} from "./types";
 import {DataModel} from "./data-model";
 
 export declare class HasParentJunction extends DataQueryable {
+    constructor(target: any, association: DataAssociationMapping | string);
     parent: DataObject;
     mapping: DataAssociationMapping;
     getBaseModel(): DataModel;

--- a/spec/DataModelFilterParser.spec.ts
+++ b/spec/DataModelFilterParser.spec.ts
@@ -1,0 +1,98 @@
+import {DataModelFilterParser} from '../data-model-filter.parser';
+import {TestApplication} from './TestApplication';
+import {DataContext} from '../types';
+import {resolve} from 'path';
+
+describe('DataModelFilterParser', () => {
+
+    let app: TestApplication;
+    let context: DataContext;
+    beforeAll((done) => {
+        app = new TestApplication(resolve(__dirname, 'test2'));
+        context = app.createContext();
+        return done();
+    });
+    afterAll(async () => {
+        await context.finalizeAsync();
+        await app.finalize();
+    });
+
+    it('should parse filter statement', async () => {
+        const Orders = context.model('Order').silent();
+        const resolver = new DataModelFilterParser(Orders);
+        const { $where, $expand } = await resolver.parseAsync(
+            `orderStatus/alternateName eq 'OrderDelivered' and orderedItem/category eq 'Laptops'`
+        );
+        const q = Orders.asQueryable();
+        Object.assign(q.query, {
+            $where,
+            $expand
+        });
+        const items: { orderStatus: any, orderedItem: { category: string } }[] = await q.take(25).getItems();
+        expect(items).toBeTruthy();
+        for (const item of items) {
+            const { orderStatus, orderedItem } = item;
+            expect(orderStatus.alternateName).toEqual('OrderDelivered');
+            expect(orderedItem.category).toEqual('Laptops');
+        }
+    });
+
+    it('should parse filter statement and execute native query', async () => {
+        const Orders = context.model('Order').silent();
+        const resolver = new DataModelFilterParser(Orders);
+        const { $where, $expand } = await resolver.parseAsync(
+            `orderStatus/alternateName eq 'OrderDelivered' and orderedItem/category eq 'Laptops'`
+        );
+        const q = Orders.asQueryable();
+        Object.assign(q.query, {
+            $where,
+            $expand
+        });
+        const { id: orderStatus} = await context.model('OrderStatusType')
+            .find({ alternateName: 'OrderDelivered' }).getItem();
+        q.select();
+        const items: any[] = await new Promise((resolve, reject) => {
+            void context.db.execute(q.query, [], (err, items) => {
+                if (err) {
+                    return reject(err);
+                }
+                return resolve(items);
+            });
+        });
+        expect(items).toBeTruthy();
+        expect(items.length).toBeGreaterThan(0);
+        for (const item of items) {
+            expect(item.orderStatus).toEqual(orderStatus);
+        }
+    });
+
+    it('should parse filter statement with previous state', async () => {
+        const Orders = context.model('Order').silent();
+        const resolver = new DataModelFilterParser(Orders);
+        const { $where, $expand } = await resolver.parseAsync(
+            `orderStatus/alternateName eq 'OrderDelivered' and orderedItem/category eq 'Laptops'`
+        );
+        const q = Orders.asQueryable();
+        Object.assign(q.query, {
+            $where,
+            $expand
+        });
+        const { id: orderStatus} = await context.model('OrderStatusType')
+            .find({ alternateName: 'OrderDelivered' }).getItem();
+        q.select();
+        const items: any[] = await new Promise((resolve, reject) => {
+            void context.db.execute(q.query, [], (err, items) => {
+                if (err) {
+                    return reject(err);
+                }
+                return resolve(items);
+            });
+        });
+        expect(items).toBeTruthy();
+        expect(items.length).toBeGreaterThan(0);
+        for (const item of items) {
+            expect(item.orderStatus).toEqual(orderStatus);
+        }
+    });
+
+});

--- a/spec/GlobalPrivileges.spec.ts
+++ b/spec/GlobalPrivileges.spec.ts
@@ -1,0 +1,435 @@
+import { resolve } from 'path';
+import { DataContext } from '../index';
+import { TestApplication } from './TestApplication';
+import { TestUtils } from './adapter/TestUtils';
+const executeInTransaction = TestUtils.executeInTransaction;
+describe('Global permissions', () => {
+    let app: TestApplication;
+    let context: DataContext;
+    beforeAll(async () => {
+        app = new TestApplication(resolve(__dirname, 'test2'));
+        context = app.createContext();
+    });
+    afterAll(async () => {
+        await context.finalizeAsync();
+        await app.finalize();
+    });
+    afterEach(() => {
+        delete context.user;
+    });
+
+    it('should validate anonymous read access to products', async () => {
+        const Products = context.model('Product');
+        const items = await Products.getItems();
+        expect(Array.isArray(items)).toBeTruthy();
+        expect(items.length).toBeTruthy();
+    });
+
+    it('should validate anonymous read access to a model which does not have privileges', async () => {
+        await context.executeInTransactionAsync(async () => {
+            await context.model('NavigationElement').silent().save({
+               name: 'Home',
+               url: '/'
+            });
+            let items = await context.model('NavigationElement').silent().getItems();
+            expect(items.length).toBeTruthy();
+            const NavigationElements = context.model('NavigationElement');
+            items = await NavigationElements.getItems();
+            expect(items.length).toBeFalsy();
+        });
+    });
+
+    it('should validate anonymous read access to nested objects', async () => {
+        await context.executeInTransactionAsync(async () => {
+            let product = await context.model('Product')
+                .where('name').equal('Samsung Galaxy S4')
+                .silent().getItem();
+            Object.assign(product, {
+                productDimensions: {
+                    height: 0.136,
+                    width: 0.069
+                }
+            });
+            await context.model('Product').silent().save(product);
+            const Products = context.model('Product');
+            const item: { productDimensions?: { height: number, width: number } } =
+                await Products.where('name').equal('Samsung Galaxy S4').expand(
+                'productDimensions'
+            ).getItem();
+            expect(item).toBeTruthy();
+            expect(item.productDimensions).toBeTruthy();
+            expect(item.productDimensions.height).toEqual(0.136);
+        });
+    });
+
+    it('should validate anonymous read access to values', async () => {
+        await context.executeInTransactionAsync(async () => {
+            let product = await context.model('Product')
+                .where('name').equal('Samsung Galaxy S4')
+                .silent().getItem();
+            Object.assign(product, {
+                keywords: [
+                    'Samsung', 'Galaxy', 'Smartphone'
+                ]
+            });
+            await context.model('Product').silent().save(product);
+            const Products = context.model('Product');
+            const item: { name: string, keywords?: string[] } =
+                await Products.where('name').equal('Samsung Galaxy S4').expand(
+                    'keywords'
+                ).getItem();
+            expect(item).toBeTruthy();
+            expect(item.keywords).toBeTruthy();
+            expect(item.keywords.length).toBeTruthy();
+        });
+    });
+
+    it('should validate that user does not have access to values', async () => {
+        await context.executeInTransactionAsync(async () => {
+            let product = await context.model('Product')
+                .where('name').equal('Samsung Galaxy S4')
+                .silent().getItem();
+            Object.assign(product, {
+                tags: [
+                    'Obsolete', 'Discontinued'
+                ]
+            });
+            await context.model('Product').silent().save(product);
+            const Products = context.model('Product');
+            let item: { name: string, tags?: string[] } =
+                await Products.where('name').equal('Samsung Galaxy S4').expand(
+                    'tags'
+                ).getItem();
+            expect(item).toBeTruthy();
+            expect(item.tags).toBeTruthy();
+            expect(item.tags.length).toBeFalsy();
+
+            const user = {
+                name: 'margaret.davis@example.com'
+            }
+            // add user to contributors
+            const group = await context.model('Group').where('name').equal('Contributors').getTypedItem();
+            expect(group).toBeTruthy();
+            const members = group.property('members').silent();
+            await members.insert(user);
+            Object.assign(context, {
+                user
+            });
+            item = await Products.where('name').equal('Samsung Galaxy S4').expand(
+                    'tags'
+                ).getItem();
+            expect(item).toBeTruthy();
+            expect(item.tags).toBeTruthy();
+            expect(item.tags.length).toBeTruthy();
+        });
+    });
+
+    it('should validate that user does not have access to many-to-many association', async () => {
+        await context.executeInTransactionAsync(async () => {
+            let itemOffered = await context.model('Product')
+                .where('name').equal('Samsung Galaxy S4')
+                .silent().getItem();
+            const price = itemOffered.price * 0.75
+            await context.model('SpecialOffer').silent().save({
+                itemOffered,
+                price,
+                validFrom: new Date(2024, 1, 1),
+                validThrough: new Date(2024, 1, 15),
+            });
+            itemOffered = await context.model('Product')
+                .where('name').equal('Samsung Galaxy S4')
+                .expand('specialOffers')
+                .silent().getItem();
+            expect(itemOffered.specialOffers).toBeTruthy();
+            expect(itemOffered.specialOffers.length).toBeTruthy();
+            const Products = context.model('Product');
+            let item: { name: string, price: number, specialOffers?: string[] } =
+                await Products.where('name').equal('Samsung Galaxy S4').expand(
+                    'specialOffers'
+                ).getItem();
+            expect(item).toBeTruthy();
+            expect(item.specialOffers).toBeTruthy();
+            expect(item.specialOffers.length).toBeFalsy();
+
+            const user = {
+                name: 'margaret.davis@example.com'
+            }
+            // add user to contributors
+            const group = await context.model('Group').where('name').equal('Contributors').getTypedItem();
+            expect(group).toBeTruthy();
+            const members = group.property('members').silent();
+            await members.insert(user);
+            Object.assign(context, {
+                user
+            });
+            item = await Products.where('name').equal('Samsung Galaxy S4').expand(
+                'tags'
+            ).getItem();
+            expect(item).toBeTruthy();
+            expect(item.specialOffers).toBeTruthy();
+            expect(item.specialOffers.length).toBeTruthy();
+
+        });
+    });
+
+    it('should validate anonymous write access to products', async () => {
+        const Products = context.model('Product');
+        const item = await Products.where('name').equal(
+            'Apple MacBook Air (13.3-inch, 2013 Version)'
+        ).getItem();
+        expect(item).toBeTruthy();
+        expect(item.name).toBe('Apple MacBook Air (13.3-inch, 2013 Version)');
+        item.model = 'APPLE-MACBOOK-AIR-13.3-2013';
+        await expect(Products.save(item)).rejects.toThrow('Access Denied');
+    });
+
+    it('should validate admin write access to products', async () => {
+        await executeInTransaction(context,async () => {
+            const Products = context.model('Product');
+            let item = await Products.where('name').equal(
+                'Apple MacBook Air (13.3-inch, 2013 Version)'
+            ).getItem();
+            Object.assign(context, {
+                user: {
+                    name: 'alexis.rees@example.com'
+                }
+            });
+            expect(item.model).not.toBe('APPLE-MACBOOK-AIR-13.3-2013');
+            expect(item).toBeTruthy();
+            expect(item.name).toBe('Apple MacBook Air (13.3-inch, 2013 Version)');
+            item.model = 'APPLE-MACBOOK-AIR-13.3-2013';
+            await expect(Products.save(item)).resolves.toBeTruthy();
+            item = await Products.where('model').equal(
+                'APPLE-MACBOOK-AIR-13.3-2013'
+            ).getItem();
+            expect(item).toBeTruthy();
+        });
+    });
+
+    it('should validate admin delete access to products', async () => {
+        await executeInTransaction(context,async () => {
+            Object.assign(context, {
+                user: {
+                    name: 'alexis.rees@example.com'
+                }
+            });
+            const Products = context.model('Product');
+            await Products.insert({
+                name: 'Apple MacBook Air (13.3-inch, 2022 Version)',
+                model: 'APPLE-MACBOOK-AIR-13.3-2022',
+                description: 'The MacBook Air is a line of laptop computers developed and manufactured by Apple Inc.',
+                keywords: [
+                    'Apple', 'MacBook', 'Air', '13.3-inch', '2022'
+                ]
+            });
+            let item = await Products.where('name').equal(
+                'Apple MacBook Air (13.3-inch, 2022 Version)'
+            ).getItem();
+            await expect(Products.remove(item)).resolves.toBeUndefined();
+            item = await Products.where('name').equal(
+                'Apple MacBook Air (13.3-inch, 2022 Version)'
+            ).getItem();
+            expect(item).toBeFalsy();
+        });
+    });
+
+    it('should validate read access to orders', async () => {
+        await executeInTransaction(context,async () => {
+            const Orders = context.model('Order');
+            const user = {
+                name: 'margaret.davis@example.com'
+            }
+            // add user to contributors
+            const group = await context.model('Group').where('name').equal('Contributors').getTypedItem();
+            expect(group).toBeTruthy();
+            const members = group.property('members').silent();
+            await members.insert(user);
+            Object.assign(context, {
+                user
+            });
+            let items = await Orders.where('orderedItem/name').equal(
+                'Apple MacBook Air (13.3-inch, 2013 Version)'
+            ).getItems();
+            expect(Array.isArray(items)).toBeTruthy();
+            expect(items.length).toBeFalsy();
+            // add read access to contributors
+            await context.model('Permission').silent().save([
+                {
+                    "privilege": "Order", // model
+                    "parentPrivilege": null,
+                    "account": {
+                        "name": "Contributors" // group
+                    },
+                    "target": 0, // all
+                    "mask": 1, // read
+                    "workspace": 1
+                }
+            ]);
+            items = await Orders.where('orderedItem/name').equal(
+                'Apple MacBook Air (13.3-inch, 2013 Version)'
+            ).getItems();
+            expect(Array.isArray(items)).toBeTruthy();
+            expect(items.length).toBeTruthy();
+
+        });
+    });
+
+    it('should validate write access to orders', async () => {
+        await executeInTransaction(context,async () => {
+            const Orders = context.model('Order');
+            const user = {
+                name: 'margaret.davis@example.com'
+            }
+            // add user to contributors
+            const group = await context.model('Group').where('name').equal('Contributors').getTypedItem();
+            expect(group).toBeTruthy();
+            const members = group.property('members').silent();
+            await members.insert(user);
+            Object.assign(context, {
+                user
+            });
+            // add read access to contributors
+            await context.model('Permission').silent().save([
+                {
+                    "privilege": "Order", // model
+                    "parentPrivilege": null,
+                    "account": {
+                        "name": "Contributors" // group
+                    },
+                    "target": 0, // all
+                    "mask": 1, // read
+                    "workspace": 1
+                }
+            ]);
+            const items = await Orders.where('orderedItem/name').equal(
+                'Apple MacBook Air (13.3-inch, 2013 Version)'
+            ).getItems();
+            const [order] = items;
+            order.orderStatus = {
+                name: 'Pickup'
+            };
+            await expect(Orders.save(order)).rejects.toThrow('Access Denied');
+
+            await context.model('Permission').silent().save([
+                {
+                    "privilege": "Order", // model
+                    "parentPrivilege": null,
+                    "account": {
+                        "name": "Contributors" // group
+                    },
+                    "target": 0, // all
+                    "mask": 4, // update
+                    "workspace": 1
+                }
+            ]);
+            await expect(Orders.save(order)).resolves.toBeTruthy();
+        });
+    });
+
+    it('should validate create access to orders', async () => {
+        await executeInTransaction(context,async () => {
+            const Orders = context.model('Order');
+            const user = {
+                name: 'margaret.davis@example.com'
+            }
+            // add user to contributors
+            const group = await context.model('Group').where('name').equal('Contributors').getTypedItem();
+            expect(group).toBeTruthy();
+            const members = group.property('members').silent();
+            await members.insert(user);
+            Object.assign(context, {
+                user
+            });
+            // add read access to contributors
+            await context.model('Permission').silent().save([
+                {
+                    "privilege": "Order", // model
+                    "parentPrivilege": null,
+                    "account": {
+                        "name": "Contributors" // group
+                    },
+                    "target": 0, // all
+                    "mask": 1, // read
+                    "workspace": 1
+                }
+            ]);
+            const items = await Orders.where('orderedItem/name').equal(
+                'Apple MacBook Air (13.3-inch, 2013 Version)'
+            ).getItems();
+            const [order] = items;
+            order.orderStatus = {
+                name: 'Pickup'
+            };
+            delete order.id;
+            order.orderNumber = '123456';
+            // and try to create a copy
+            await expect(Orders.insert(order)).rejects.toThrow('Access Denied');
+            await context.model('Permission').silent().save([
+                {
+                    "privilege": "Order", // model
+                    "parentPrivilege": null,
+                    "account": {
+                        "name": "Contributors" // group
+                    },
+                    "target": 0, // all
+                    "mask": 2, // create
+                    "workspace": 1
+                }
+            ]);
+            await expect(Orders.insert(order)).resolves.toBeTruthy();
+            await expect(Orders.where('orderNumber').equal('123456').getItem()).resolves.toBeTruthy();
+        });
+    });
+
+    it('should validate delete access to orders', async () => {
+        await executeInTransaction(context,async () => {
+            const Orders = context.model('Order');
+            const user = {
+                name: 'margaret.davis@example.com'
+            }
+            // add user to contributors
+            const group = await context.model('Group').where('name').equal('Contributors').getTypedItem();
+            expect(group).toBeTruthy();
+            const members = group.property('members').silent();
+            await members.insert(user);
+            Object.assign(context, {
+                user
+            });
+            // add read access to contributors
+            await context.model('Permission').silent().save([
+                {
+                    "privilege": "Order", // model
+                    "parentPrivilege": null,
+                    "account": {
+                        "name": "Contributors" // group
+                    },
+                    "target": 0, // all
+                    "mask": 1, // read
+                    "workspace": 1
+                }
+            ]);
+            const items = await Orders.where('orderedItem/name').equal(
+                'Apple MacBook Air (13.3-inch, 2013 Version)'
+            ).getItems();
+            const [order] = items;
+            order.orderStatus = {
+                name: 'Pickup'
+            };
+            await expect(Orders.remove(order)).rejects.toThrow('Access Denied');
+            await context.model('Permission').silent().save([
+                {
+                    "privilege": "Order", // model
+                    "parentPrivilege": null,
+                    "account": {
+                        "name": "Contributors" // group
+                    },
+                    "target": 0, // all
+                    "mask": 8, // delete
+                    "workspace": 1
+                }
+            ]);
+            await expect(Orders.remove(order)).resolves.toBeUndefined();
+            await expect(Orders.where('id').equal(order.id).getItem()).resolves.toBeFalsy();
+        });
+    });
+});

--- a/spec/ParentPrivileges.spec.ts
+++ b/spec/ParentPrivileges.spec.ts
@@ -1,0 +1,90 @@
+import { resolve } from 'path';
+import { DataContext } from '../index';
+import { TestApplication } from './TestApplication';
+import { TestUtils } from './adapter/TestUtils';
+const executeInTransaction = TestUtils.executeInTransaction;
+
+interface DataContextWithUser extends DataContext {
+    user: any
+}
+
+describe('Parent permissions', () => {
+    let app: TestApplication;
+    let context: DataContextWithUser;
+    beforeAll(async () => {
+        app = new TestApplication(resolve(__dirname, 'test2'));
+        context = app.createContext() as DataContextWithUser;
+    });
+    afterAll(async () => {
+        await context.finalizeAsync();
+        await app.finalize();
+    });
+    afterEach(() => {
+        delete context.user;
+    });
+
+    it('should allow to read objects based on parent', async () => {
+        await executeInTransaction(context, async () => {
+            // create merchant
+            const merchant : { id?: number, name: string, email: string, telephone: string} = {
+                name: 'Weber and Sons',
+                email: 'weber-and-sons@example.com',
+                telephone: '+441234567890'
+            };
+            await context.model('Party').silent().save(merchant);
+            // create order
+            const order = {
+                merchant,
+                orderedItem: {
+                    name: 'Samsung Galaxy S4'
+                },
+                orderStatus: {
+                    name: 'Processing'
+                },
+                customer: {
+                    email: 'collin.jenkins@example.com'
+                }
+            };
+            await context.model('Order').silent().save(order);
+            // create user
+            const user = {
+                name: 'tommy.jenkins@example.com',
+            }
+            await context.model('User').silent().save(user);
+            // create Merchants
+            await context.model('Group').silent().save({
+                name: 'Merchants',
+                members: [{
+                    name: 'tommy.jenkins@example.com'
+                }]
+            });
+            // create group for the merchant
+            const group = {
+                name: 'Weber and Sons Merchants',
+                alternateName: 'WeberAndSonsMerchants',
+                members: [{
+                    name: 'tommy.jenkins@example.com'
+                }]
+            };
+
+            await context.model('Group').silent().save(group);
+            // set permission based on parent
+            // which is a merchant
+            // the users who are in the group 'Weber and Sons Merchants' can read the orders
+            // made by the merchant 'Weber and Sons'
+            await context.model('Permission').silent().save({
+                privilege: 'Order',
+                parentPrivilege: 'merchant',
+                account: {
+                    name: 'Weber and Sons Merchants'
+                },
+                mask: 1,
+                target: merchant.id // set target id which the identifier of the merchant
+            });
+            context.user = user;
+            const items = await context.model('Order').getItems();
+            expect(items.length).toBe(1);
+        });
+    });
+
+});

--- a/spec/test2/config/models/Order.json
+++ b/spec/test2/config/models/Order.json
@@ -216,6 +216,13 @@
             "account": "Administrators"
         },
         {
+            "mask": 15,
+            "description": "Read, create, update or delete orders based on privileges given for a specific merchant.",
+            "type": "parent",
+            "account": "Merchants",
+            "property": "merchant"
+        },
+        {
             "mask": 1,
             "type": "self",
             "filter": "customer/user eq me()"

--- a/spec/test2/config/models/OrderAction.json
+++ b/spec/test2/config/models/OrderAction.json
@@ -52,8 +52,30 @@
             "account": "Administrators"
         },
         {
-            "mask": 15,
+            "mask": 1,
+            "description": "An agent can read order actions",
+            "type": "global",
+            "account": "Contributors"
+        },
+        {
+            "mask": 2,
             "type": "self",
+            "description": "Allow create order actions with potential status",
+            "account": "Contributors",
+            "filter": "agent/user eq me() and actionStatus/alternateName eq 'PotentialActionStatus'"
+        },
+        {
+            "mask": 4,
+            "type": "self",
+            "description": "Allow update order actions when action status is potential",
+            "account": "Contributors",
+            "when": "agent/user eq me() and actionStatus/alternateName eq 'PotentialActionStatus'",
+            "filter": "agent/user eq me() and (actionStatus/alternateName eq 'PotentialActionStatus' or actionStatus/alternateName eq 'ActiveActionStatus')"
+        },
+        {
+            "mask": 8,
+            "type": "self",
+            "description": "Allow delete order actions when action status is potential",
             "account": "Contributors",
             "filter": "agent/user eq me() and actionStatus/alternateName eq 'PotentialActionStatus'"
         }

--- a/spec/test2/config/models/Product.json
+++ b/spec/test2/config/models/Product.json
@@ -58,6 +58,35 @@
             "type": "Date"
         },
         {
+            "name": "tags",
+            "title": "Tag",
+            "many": true,
+            "type": "Text",
+            "mapping": {
+                "associationAdapter": "ProductTags",
+                "associationType": "junction",
+                "cascade": "delete",
+                "associationObjectField": "product",
+                "associationValueField": "value",
+                "privileges": [
+                    {
+                        "mask": 15,
+                        "type": "global"
+                    },
+                    {
+                        "mask": 15,
+                        "type": "global",
+                        "account": "Administrators"
+                    },
+                    {
+                        "mask": 15,
+                        "type": "global",
+                        "account": "Contributors"
+                    }
+                ]
+            }
+        },
+        {
             "name": "keywords",
             "title": "Keyword",
             "description": "The release date of a product or product model. This can be used to distinguish the exact variant of a product.",

--- a/spec/test2/config/models/ProductDimension.json
+++ b/spec/test2/config/models/ProductDimension.json
@@ -26,5 +26,21 @@
                 "product"
             ]
         }
+    ],
+    "privileges": [
+        {
+            "mask": 1,
+            "type": "global",
+            "account": "*"
+        },
+        {
+            "mask": 15,
+            "type": "global"
+        },
+        {
+            "mask": 15,
+            "type": "global",
+            "account": "Administrators"
+        }
     ]
 }

--- a/spec/test2/config/models/SpecialOffer.json
+++ b/spec/test2/config/models/SpecialOffer.json
@@ -9,9 +9,26 @@
             "title": "itemOffered",
             "description": "The item being offered.",
             "type": "Product",
+            "editable": false,
             "nullable": false
         }
     ],
     "constraints": [
+    ],
+    "privileges": [
+        {
+            "mask": 15,
+            "type": "global"
+        },
+        {
+            "mask": 15,
+            "type": "global",
+            "account": "Administrators"
+        },
+        {
+            "mask": 15,
+            "type": "global",
+            "account": "Contributors"
+        }
     ]
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -86,6 +86,7 @@ export declare interface DataModelPrivilege {
     type: string;
     mask: number;
     account?: string;
+    when?: string;
     filter?: string;
     scope?: string[];
     exclude?: string;

--- a/types.js
+++ b/types.js
@@ -758,6 +758,9 @@ var PrivilegeType = {
  * The defined set of permissions are automatically assigned if the requested objects fulfill filter criteria.
  * (e.g. read-write permissions for a user's associated person through the following expression:"user eq me()")
  * @property {string} account - Gets or sets a wildcard (*) expression for global privileges only.
+ * @property {string} when - Gets or sets a filter expression which is going to be used for self privileges.
+ * @property {string} exclude - Gets or sets a condition for excluding the given privilege based on that condition.
+ * @property {Array<string>} scope - Gets or sets a collection of client scopes which are required for validating this privilege.
  * The defined set of permissions are automatically assigned to all users (e.g. read permissions for all users)
  */
 function DataModelPrivilege() {


### PR DESCRIPTION
This PR implements `when` conditiion of `DataModelPrivilege`. This operation upgrades the validation of self permissions by getting original data while checking the state of an object e.g.
```
{
            "mask": 4,
            "type": "self",
            "description": "Allow update order actions when action status is potential",
            "account": "Contributors",
            "when": "agent/user eq me() and actionStatus/alternateName eq 'PotentialActionStatus'",
            "filter": "agent/user eq me() and (actionStatus/alternateName eq 'PotentialActionStatus' or actionStatus/alternateName eq 'ActiveActionStatus')"
        },
```
where a contributor has the permission to update an order when they claimed the given order -agent is equal to current user- and order start is pending.
This specific privilege defines also that a contributor is eligible to activate an order  -to update the order status from `PotentialActionStatus` to `ActiveActionStatus`-