### PR TITLE
reset nested query expression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.14.0",
+      "version": "2.14.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR updates nested query mechanism and generates query expressions if this operation is required by an attribute e.g. an zero-or-one multiplicity association has a `$filter` which should be applied while getting nested attributes. 