### PR TITLE
set model name for a zero-or-one junction

### DIFF
--- a/data-queryable.js
+++ b/data-queryable.js
@@ -674,7 +674,7 @@ DataAttributeResolver.prototype.resolveJunctionAttributeJoin = function(attr) {
                     configurable: true,
                     enumerable: false,
                     writable: true,
-                    value: mapping.associationAdapter
+                    value: childModel.name
                 });
                 expr = QueryUtils.query().where(QueryField.select(mapping.associationValueField).from(field.name))
                     .equal(QueryField.select(mapping.childField).from(alias));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.6.52",
+  "version": "2.6.53",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.6.52",
+      "version": "2.6.53",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.52",
+  "version": "2.6.53",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Fixes an error occurred while selecting an attribute from a many-to-many association with zero or one multiplicity.