### PR TITLE
Validate where statement

### DIFF
--- a/data-queryable.js
+++ b/data-queryable.js
@@ -6,7 +6,7 @@ var _ = require('lodash');
 var {TextUtils} = require('@themost/common');
 var {DataMappingExtender} = require('./data-mapping-extensions');
 var {DataAssociationMapping} = require('./types');
-var {DataError} = require('@themost/common');
+var {DataError, Args} = require('@themost/common');
 var {QueryField} = require('@themost/query');
 var {QueryEntity} = require('@themost/query');
 var {QueryUtils} = require('@themost/query');
@@ -853,6 +853,7 @@ DataQueryable.prototype.prepare = function(useOr) {
     });
  */
 DataQueryable.prototype.where = function(attr) {
+    Args.check(this.query.$where == null, new Error('The where expression has already been initialized.'));
     if (typeof attr === 'string' && /\//.test(attr)) {
         this.query.where(DataAttributeResolver.prototype.resolveNestedAttribute.call(this, attr));
         return this;

--- a/spec/DataQueryable.spec.ts
+++ b/spec/DataQueryable.spec.ts
@@ -17,6 +17,9 @@ describe('DataQueryable', () => {
         await app.finalize();
     });
 
+    /**
+     * @see https://github.com/themost-framework/data/issues/161
+     */
     it('should validate where statement', async () => {
         const Orders = context.model('Order').silent();
         const items = await Orders.where('orderStatus/alternateName').equal('OrderDelivered')
@@ -25,6 +28,9 @@ describe('DataQueryable', () => {
         expect(items.length).toBeGreaterThan(0);
     });
 
+    /**
+     * @see https://github.com/themost-framework/data/issues/161
+     */
     it('should validate where statement with error', async () => {
         const Orders = context.model('Order').silent();
         const q = Orders.where('orderStatus/alternateName').equal('OrderDelivered')
@@ -32,6 +38,9 @@ describe('DataQueryable', () => {
         expect(() => q.where('orderedItem/category').equal('Laptops')).toThrow('The where expression has already been initialized.');
     });
 
+    /**
+     * @see https://github.com/themost-framework/data/issues/161
+     */
     it('should validate where statement after prepare', async () => {
         const Orders = context.model('Order').silent();
         const q = Orders.where('orderStatus/alternateName').equal('OrderDelivered')

--- a/spec/DataQueryable.spec.ts
+++ b/spec/DataQueryable.spec.ts
@@ -1,0 +1,42 @@
+import {DataModelFilterParser} from '../data-model-filter.parser';
+import {TestApplication} from './TestApplication';
+import {DataContext} from '../types';
+import {resolve} from 'path';
+
+describe('DataQueryable', () => {
+
+    let app: TestApplication;
+    let context: DataContext;
+    beforeAll((done) => {
+        app = new TestApplication(resolve(__dirname, 'test2'));
+        context = app.createContext();
+        return done();
+    });
+    afterAll(async () => {
+        await context.finalizeAsync();
+        await app.finalize();
+    });
+
+    it('should validate where statement', async () => {
+        const Orders = context.model('Order').silent();
+        const items = await Orders.where('orderStatus/alternateName').equal('OrderDelivered')
+            .orderByDescending('orderDate').take(10).getItems();
+        expect(items).toBeTruthy();
+        expect(items.length).toBeGreaterThan(0);
+    });
+
+    it('should validate where statement with error', async () => {
+        const Orders = context.model('Order').silent();
+        const q = Orders.where('orderStatus/alternateName').equal('OrderDelivered')
+            .orderByDescending('orderDate').take(10);
+        expect(() => q.where('orderedItem/category').equal('Laptops')).toThrow('The where expression has already been initialized.');
+    });
+
+    it('should validate where statement after prepare', async () => {
+        const Orders = context.model('Order').silent();
+        const q = Orders.where('orderStatus/alternateName').equal('OrderDelivered')
+            .orderByDescending('orderDate').take(10);
+        expect(() => q.prepare().where('orderedItem/category').equal('Laptops')).toBeTruthy();
+    });
+
+});


### PR DESCRIPTION
This PR closes #161 and validates the existing where statement of an instance of `DataQueryable` when using `DataQueryable.where(expr)` and throws an error if has been already defined e.g. a DataQueryable instance is being used for getting a list of orders and the process is trying to add an extra clause by using again `where(expr)`. This statement will throw an exception: "The where expression has already been initialized.".

```js
const q = Orders.where('orderStatus/alternateName').equal('OrderDelivered')
            .orderByDescending('orderDate').take(10);
q.where('orderedItem/category').equal('Laptops');
```

