### PR TITLE
implement custom query expression for attributes

### DIFF
--- a/data-field-query-resolver.js
+++ b/data-field-query-resolver.js
@@ -43,7 +43,7 @@ class DataFieldQueryResolver {
                     }
                 }
                 throw new DataError('An expression contains an attribute that cannot be found', null, this.target.name, name);
-            } else if (/^\$(\w+\.\w+)+$/.test(value)) {
+            } else if (/^\$(\w+)\.(\w+)$/.test(value)) {
                 return {
                     $name: value.replace(/^\$/, '')
                 }

--- a/data-field-query-resolver.js
+++ b/data-field-query-resolver.js
@@ -43,7 +43,7 @@ class DataFieldQueryResolver {
                     }
                 }
                 throw new DataError('An expression contains an attribute that cannot be found', null, this.target.name, name);
-            } else if (/^\$((\w+)(\.(\w+)){1,})$/.test(value)) {
+            } else if (/^\$((\w+)(\.(\w+))+)$/.test(value)) {
                 return {
                     $name: value.replace(/^\$/, '')
                 }
@@ -81,7 +81,7 @@ class DataFieldQueryResolver {
                             // get expression as string
                             const exprString = JSON.stringify(pipelineStage.$match.$expr, function(key, value) {
                                 if (typeof value === 'string') {
-                                    if (/\$\$(\w+)/g.test(value)) {
+                                    if (/\$\$(\w+)/.test(value)) {
                                         let localField = /\$\$(\w+)/.exec(value)[1];
                                         let localFieldAttribute = self.target.getAttribute(localField);
                                         if (localFieldAttribute && localFieldAttribute.model === self.target.name) {
@@ -119,7 +119,7 @@ class DataFieldQueryResolver {
                     });
                 } else {
                     let localField = this.formatName(stage.$lookup.localField);
-                    if (/\./g.test(localField) === false) {
+                    if (/\./.test(localField) === false) {
                         // get local field expression
                         let localFieldAttribute = this.target.getAttribute(localField);
                         if (localFieldAttribute && localFieldAttribute.model === this.target.name) {

--- a/data-field-query-resolver.js
+++ b/data-field-query-resolver.js
@@ -44,7 +44,7 @@ class DataFieldQueryResolver {
                 }
                 throw new DataError('An expression contains an attribute that cannot be found', null, this.target.name, name);
             } else { // noinspection RegExpUnnecessaryNonCapturingGroup
-                if (/^\$\w+\.(?:\w+)$/.test(value)) {
+                if (/^\$\w+\.\w+$/.test(value)) {
                                 return {
                                     $name: value.replace(/^\$/, '')
                                 }

--- a/data-field-query-resolver.js
+++ b/data-field-query-resolver.js
@@ -23,7 +23,7 @@ class DataFieldQueryResolver {
 
     nameReplacer(key, value) {
         if (typeof value === 'string') {
-            if (/^\$(\w+)$/.test(value)) {
+            if (/^\$\w+$/.test(value)) {
                 const baseModel = this.target.base();
                 const name = value.replace(/^\$/, '');
                 let field = null;
@@ -43,7 +43,7 @@ class DataFieldQueryResolver {
                     }
                 }
                 throw new DataError('An expression contains an attribute that cannot be found', null, this.target.name, name);
-            } else if (/^\$((\w+)(\.(\w+))+)$/.test(value)) {
+            } else if (/^\$(\w+\.\w+)+$/.test(value)) {
                 return {
                     $name: value.replace(/^\$/, '')
                 }
@@ -81,7 +81,7 @@ class DataFieldQueryResolver {
                             // get expression as string
                             const exprString = JSON.stringify(pipelineStage.$match.$expr, function(key, value) {
                                 if (typeof value === 'string') {
-                                    if (/\$\$(\w+)/.test(value)) {
+                                    if (/\$\$\w+/.test(value)) {
                                         let localField = /\$\$(\w+)/.exec(value)[1];
                                         let localFieldAttribute = self.target.getAttribute(localField);
                                         if (localFieldAttribute && localFieldAttribute.model === self.target.name) {

--- a/data-field-query-resolver.js
+++ b/data-field-query-resolver.js
@@ -1,0 +1,192 @@
+const {Args, DataError} = require('@themost/common');
+const {hasOwnProperty} = require('./has-own-property');
+const {QueryEntity, QueryExpression, QueryField} = require('@themost/query');
+class DataFieldQueryResolver {
+    /**
+     * @param {import("./data-model").DataModel} target
+     */
+    constructor(target) {
+        this.target = target;
+    }
+
+    /**
+     *
+     * @param {string} value
+     * @returns {string}
+     */
+    formatName(value) {
+        if (/^\$/.test(value)) {
+            return value.replace(/(\$?(\w+)?)/g, '$2').replace(/\.(\w+)/g, '.$1')
+        }
+        return value;
+    }
+
+    nameReplacer(key, value) {
+        if (typeof value === 'string') {
+            if (/^\$(\w+)$/.test(value)) {
+                const baseModel = this.target.base();
+                const name = value.replace(/^\$/, '');
+                let field = null;
+                let collection = null;
+                // try to find if field belongs to base model
+                if (baseModel) {
+                    field = baseModel.getAttribute(name);
+                    collection = baseModel.viewAdapter;
+                }
+                if (field == null) {
+                    collection = this.target.sourceAdapter;
+                    field = this.target.getAttribute(name);
+                }
+                if (field) {
+                    return {
+                        $name: collection + '.' + name
+                    }
+                }
+                throw new DataError('An expression contains an attribute that cannot be found', null, this.target.name, name);
+            } else if (/^\$((\w+)(\.(\w+)){1,})$/.test(value)) {
+                return {
+                    $name: value.replace(/^\$/, '')
+                }
+            }
+        }
+        return value;
+    }
+
+    /**
+     * @param {import("./types").DataField} field
+     * @returns {{$select?: import("@themost/query").QueryField, $expand?: import("@themost/query").QueryEntity[]}|null}
+     */
+    resolve(field) {
+        Args.check(field != null, new DataError('E_FIELD','Field may not be null', null, this.target.name));
+        if (Array.isArray(field.query) === false) {
+            return {
+                select: null,
+                expand: []
+            };
+        }
+        let expand = [];
+        let select = null;
+        const self = this;
+        // get base model
+        const baseModel = this.target.base();
+        for (const stage of field.query) {
+            if (stage.$lookup) {
+                // get from model
+                const from = stage.$lookup.from;
+                const fromModel = this.target.context.model(from);
+                if (stage.$lookup.pipeline && stage.$lookup.pipeline.length) {
+                    stage.$lookup.pipeline.forEach(function(pipelineStage) {
+                        if (pipelineStage.$match && pipelineStage.$match.$expr) {
+                            const q = new QueryExpression().select('*').from(self.target.sourceAdapter);
+                            // get expression as string
+                            const exprString = JSON.stringify(pipelineStage.$match.$expr, function(key, value) {
+                                if (typeof value === 'string') {
+                                    if (/\$\$(\w+)/g.test(value)) {
+                                        let localField = /\$\$(\w+)/.exec(value)[1];
+                                        let localFieldAttribute = self.target.getAttribute(localField);
+                                        if (localFieldAttribute && localFieldAttribute.model === self.target.name) {
+                                            return { 
+                                                $name: self.target.sourceAdapter + '.' + localField
+                                            }
+                                        }
+                                        if (baseModel) {
+                                            localFieldAttribute = baseModel.getAttribute(localField);
+                                            if (localFieldAttribute) {
+                                                return { 
+                                                    $name: baseModel.viewAdapter + '.' + localField
+                                                }
+                                            }
+                                        }
+                                        throw new DataError('E_FIELD', 'Data field cannot be found', null, self.target.name, localField);
+                                    }
+                                }
+                                return self.nameReplacer(key, value);
+                            });
+                             const joinCollection = new QueryEntity(fromModel.viewAdapter).as(stage.$lookup.as).left();
+                             Object.defineProperty(joinCollection, 'model', {
+                                 configurable: true,
+                                 enumerable: false,
+                                 writable: true,
+                                 value: fromModel.name
+                             });
+                             const joinExpression = Object.assign(new QueryExpression(), {
+                                $where: JSON.parse(exprString)
+                             });
+                            q.join(joinCollection).with(joinExpression);
+                            const appendExpand = [].concat(q.$expand);
+                            expand.push.apply(expand, appendExpand);
+                        }
+                    });
+                } else {
+                    let localField = this.formatName(stage.$lookup.localField);
+                    if (/\./g.test(localField) === false) {
+                        // get local field expression
+                        let localFieldAttribute = this.target.getAttribute(localField);
+                        if (localFieldAttribute && localFieldAttribute.model === this.target.name) {
+                            localField = `${this.target.sourceAdapter}.${localField}`;
+                        } else {
+                            // get base model
+                            const baseModel = this.target.base();
+                            if (baseModel) {
+                                localFieldAttribute = baseModel.getAttribute(localField);
+                                if (localFieldAttribute) {
+                                    localField = `${baseModel.viewAdapter}.${localField}`;
+                                }
+                            }
+                        }
+                    }
+                    const foreignField = this.formatName(stage.$lookup.foreignField);
+                    const q = new QueryExpression().select('*').from(this.target.sourceAdapter);
+                    Args.check(fromModel != null, new DataError('E_MODEL', 'Data model cannot be found', null, from));
+                    const joinCollection = new QueryEntity(fromModel.viewAdapter).as(stage.$lookup.as).left();
+                    Object.defineProperty(joinCollection, 'model', {
+                        configurable: true,
+                        enumerable: false,
+                        writable: true,
+                        value: fromModel.name
+                    });
+                    q.join(joinCollection).with(
+                        new QueryExpression().where(new QueryField(localField))
+                            .equal(new QueryField(foreignField).from(stage.$lookup.as))
+                    );
+                    const appendExpand = [].concat(q.$expand);
+                    expand.push.apply(expand, appendExpand);
+                }
+            }
+            const name = field.property || field.name;
+            if (stage.$project) {
+                Args.check(hasOwnProperty(stage.$project, name), new DataError('E_QUERY', 'Field projection expression is missing.', null, this.target.name, field.name));
+                const expr = Object.getOwnPropertyDescriptor(stage.$project, name).value;
+                if (typeof expr === 'string') {
+                    select = new QueryField(this.formatName(expr)).as(name)
+                } else {
+                    const expr1 = Object.defineProperty({}, name, {
+                        configurable: true,
+                        enumerable: true,
+                        writable: true,
+                        value: expr
+                    });
+                    // Important note: Field references e.g. $customer.email
+                    // are not supported by @themost/query@Formatter
+                    // and should be replaced by name references e.g. { "$name": "customer.email" }
+                    // A workaround is being used here is a regular expression replacer which 
+                    // will try to replace  "$customer.email" with { "$name": "customer.email" }
+                    // but this operation is definitely a feature request for @themost/query
+                    const finalExpr = JSON.parse(JSON.stringify(expr1, function(key, value) {
+                        return self.nameReplacer(key, value);
+                    }));
+                    select = Object.assign(new QueryField(), finalExpr);
+                }
+            }
+        }
+        return {
+            $select: select,
+            $expand: expand
+        }
+    }
+
+}
+
+module.exports = {
+    DataFieldQueryResolver
+}

--- a/data-field-query-resolver.js
+++ b/data-field-query-resolver.js
@@ -43,10 +43,12 @@ class DataFieldQueryResolver {
                     }
                 }
                 throw new DataError('An expression contains an attribute that cannot be found', null, this.target.name, name);
-            } else if (/^\$\w+\.(\w+)$/.test(value)) {
-                return {
-                    $name: value.replace(/^\$/, '')
-                }
+            } else { // noinspection RegExpUnnecessaryNonCapturingGroup
+                if (/^\$\w+\.(?:\w+)$/.test(value)) {
+                                return {
+                                    $name: value.replace(/^\$/, '')
+                                }
+                            }
             }
         }
         return value;

--- a/data-field-query-resolver.js
+++ b/data-field-query-resolver.js
@@ -43,7 +43,7 @@ class DataFieldQueryResolver {
                     }
                 }
                 throw new DataError('An expression contains an attribute that cannot be found', null, this.target.name, name);
-            } else if (/^\$(\w+)\.(\w+)$/.test(value)) {
+            } else if (/^\$\w+\.(\w+)$/.test(value)) {
                 return {
                     $name: value.replace(/^\$/, '')
                 }

--- a/data-model.js
+++ b/data-model.js
@@ -2286,8 +2286,19 @@ DataModel.prototype.migrate = function(callback)
         return callback(null, false);
     }
     var context = self.context;
-    //do migration
+    // do migration
     var fields = self.attributes.filter(function(x) {
+        if (x.insertable === false && x.editable === false && x.model === self.name) {
+            if (typeof x.query === 'undefined') {
+                throw new DataError('E_MODEL', 'A non-insertable and non-editable field should have a custom query defined.', null, self.name, x.name);
+            }
+            // validate source and view
+            if (self.sourceAdapter === self.viewAdapter) {
+                throw new DataError('E_MODEL', 'A data model with the same source and view data object cannot have virtual columns.', null, self.name, x.name);
+            }
+            // exclude virtual column
+            return false;
+        }
         return (self.name === x.model) && (!x.many);
     });
 

--- a/model-schema.json
+++ b/model-schema.json
@@ -315,8 +315,57 @@
                             },
                             "validator": {
                                 "type": "string",
-                                "description": "A string which represetns the module path that exports a custom validator e.g. ./validators/custom-validator.js"
+                                "description": "A string which represents the module path that exports a custom validator e.g. ./validators/custom-validator.js"
                             }
+                        }
+                    },
+                    "query": {
+                        "type": "array",
+                        "description": "Defines a custom query expression to be used while selecting field.",
+                        "items": {
+                            "anyOf":[
+                                {
+                                    "type": "object",
+                                    "$lookup": {
+                                        "type": "object",
+                                        "properties": {
+                                            "from": {
+                                                "type": "string"
+                                            },
+                                            "localField": {
+                                                "type": "string"
+                                            },
+                                            "foreignField": {
+                                                "type": "string"
+                                            },
+                                            "let": {
+                                                "type": "object",
+                                                "additionalProperties": true
+                                            },
+                                            "pipeline": {
+                                                "type": "object",
+                                                "additionalProperties": true
+                                            },
+                                            "as": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "additionalProperties": true,
+                                        "required": [
+                                            "from"
+                                        ],
+                                        "description": "A query expression for joining other data models"
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "$project": {
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "description": "A query expression for selecting field"
+                                    }
+                                }
+                            ]
                         }
                     }
                 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.6.55",
+  "version": "2.6.56",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.6.55",
+      "version": "2.6.56",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.55",
+  "version": "2.6.56",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "types": "index.d.ts",

--- a/spec/CustomQueryExpr.spec.ts
+++ b/spec/CustomQueryExpr.spec.ts
@@ -1,0 +1,467 @@
+import {TestUtils} from './adapter/TestUtils';
+import { TestApplication } from './TestApplication';
+import { DataContext } from '../types';
+import { DataConfigurationStrategy } from '../data-configuration';
+import {SqliteAdapter} from '@themost/sqlite';
+import { resolve } from 'path';
+
+const TempOrderSchema = {
+    "name": "TempOrder",
+    "version": "3.0.0",
+    "fields": [
+        {
+            "@id": "https://themost.io/schemas/id",
+            "name": "id",
+            "title": "ID",
+            "description": "The identifier of the item.",
+            "type": "Counter",
+            "primary": true
+        },
+        {
+            "name": "acceptedOffer",
+            "title": "Accepted Offer",
+            "description": "The offer e.g. product included in the order.",
+            "type": "Offer"
+        },
+        {
+            "name": "customer",
+            "title": "Customer",
+            "description": "Party placing the order.",
+            "type": "Person",
+            "editable": false,
+            "nullable": false
+        },
+        {
+            "name": "orderDate",
+            "title": "Order Date",
+            "description": "Date order was placed.",
+            "type": "DateTime",
+            "value": "javascript:return new Date();"
+        },
+        {
+            "name": "orderEmail",
+            "readonly": true,
+            "type": 'Text',
+            "nullable": true,
+            "query": [
+                {
+                    "$lookup": {
+                        "from": "Person",
+                        "foreignField": "id",
+                        "localField": "customer",
+                        "as": "customer"
+                    }
+                },
+                {
+                    "$project": {
+                        "orderEmail": "$customer.email"
+                    }
+                }
+            ]
+        },
+        {
+            "name": 'orderAddressLocality',
+            "readonly": true,
+            "type": 'Text',
+            "nullable": true,
+            "query": [
+                {
+                    "$lookup": {
+                        "from": "Person",
+                        "foreignField": "id",
+                        "localField": "customer",
+                        "as": "customer"
+                    }
+                },
+                {
+                    "$lookup": {
+                        "from": "PostalAddress",
+                        "foreignField": "id",
+                        "localField": "$customer.address",
+                        "as": "address"
+                    }
+                },
+                {
+                    "$project": {
+                        "orderAddressLocality": "$address.addressLocality"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "orderedItem",
+            "title": "Ordered Item",
+            "description": "The item ordered.",
+            "type": "Product",
+            "expandable": true,
+            "editable": true,
+            "nullable": false
+        }
+    ],
+    "privileges": [
+        {
+            "mask": 15,
+            "type": "global"
+        },
+        {
+            "mask": 15,
+            "type": "global",
+            "account": "Administrators"
+        },
+        {
+            "mask": 1,
+            "type": "self",
+            "filter": "customer/user eq me()"
+        }
+    ]
+};
+
+const NewOrderSchema = {
+    "name": "NewOrder",
+    "version": "3.0.0",
+    "fields": [
+        {
+            "@id": "https://themost.io/schemas/id",
+            "name": "id",
+            "type": "Counter",
+            "primary": true
+        },
+        {
+            "name": "acceptedOffer",
+            "type": "Offer"
+        },
+        {
+            "name": "customer",
+            "type": "Person",
+            "editable": false,
+            "nullable": false
+        },
+        {
+            "name": "orderDate",
+            "type": "DateTime",
+            "value": "javascript:return new Date();"
+        },
+        {
+            "name": "orderedItem",
+            "type": "Product",
+            "expandable": true,
+            "editable": true,
+            "nullable": false
+        },
+        {
+            "name": "priceCategory",
+            "readonly": true,
+            "type": 'Text',
+            "nullable": true,
+            "query": [
+                {
+                    "$lookup": {
+                        "from": "Person",
+                        "foreignField": "id",
+                        "localField": "customer",
+                        "as": "customer"
+                    }
+                },
+                {
+                    "$lookup": {
+                        "from": "Product",
+                        "foreignField": "id",
+                        "localField": "orderedItem",
+                        "as": "orderedItem"
+                    }
+                },
+                {
+                    "$project": {
+                        "priceCategory": {
+                            "$cond": [
+                                {
+                                    "$gt": [
+                                        "$orderedItem.price",
+                                        1000
+                                    ]
+                                },
+                                'Expensive',
+                                'Normal'
+                            ]
+                        }
+                    }
+                }
+            ]
+        },
+    ],
+    "privileges": [
+        {
+            "mask": 15,
+            "type": "global"
+        },
+        {
+            "mask": 15,
+            "type": "global",
+            "account": "Administrators"
+        },
+        {
+            "mask": 1,
+            "type": "self",
+            "filter": "customer/user eq me()"
+        }
+    ]
+};
+
+const NewLocalOrderSchema = {
+    "name": "NewLocalOrder",
+    "version": "3.0.0",
+    "fields": [
+        {
+            "@id": "https://themost.io/schemas/id",
+            "name": "id",
+            "title": "ID",
+            "description": "The identifier of the item.",
+            "type": "Counter",
+            "primary": true
+        },
+        {
+            "name": "acceptedOffer",
+            "title": "Accepted Offer",
+            "description": "The offer e.g. product included in the order.",
+            "type": "Offer"
+        },
+        {
+            "name": "customer",
+            "title": "Customer",
+            "description": "Party placing the order.",
+            "type": "Person",
+            "editable": false,
+            "nullable": false
+        },
+        {
+            "name": "orderDate",
+            "title": "Order Date",
+            "description": "Date order was placed.",
+            "type": "DateTime",
+            "value": "javascript:return new Date();"
+        },
+        {
+            "name": "orderEmail",
+            "readonly": true,
+            "type": 'Text',
+            "nullable": true,
+            "query": [
+                {
+                    "$lookup": {
+                        "from": "Person",
+                        "pipeline": [
+                            {
+                                "$match": {
+                                    "$expr": {
+                                        "$eq": [ "$$customer", "$customer.id" ]
+                                    }
+                                }
+                            }
+                        ],
+                        "as": "customer"
+                    }
+                },
+                {
+                    "$project": {
+                        "orderEmail": "$customer.email"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "orderedItem",
+            "title": "Ordered Item",
+            "description": "The item ordered.",
+            "type": "Product",
+            "expandable": true,
+            "editable": true,
+            "nullable": false
+        }
+    ],
+    "privileges": [
+        {
+            "mask": 15,
+            "type": "global"
+        },
+        {
+            "mask": 15,
+            "type": "global",
+            "account": "Administrators"
+        },
+        {
+            "mask": 1,
+            "type": "self",
+            "filter": "customer/user eq me()"
+        }
+    ]
+};
+
+const ExtendedProductSchema = {
+    "name": "ExtendedProduct",
+    "version": "3.0.0",
+    "inherits": "Product",
+    "fields": [
+        {
+            "name": "priceCategory",
+            "type": "Text",
+            "readonly": true,
+            "insertable": false,
+            "editable": false,
+            "nullable": true,
+            "query": [
+                {
+                    "$project": {
+                        "priceCategory": {
+                            "$cond": [
+                                {
+                                    "$gt": [
+                                        "$price",
+                                        1000
+                                    ]
+                                },
+                                'Expensive',
+                                'Normal'
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "privileges": [
+        {
+            "mask": 15,
+            "type": "global"
+        },
+        {
+            "mask": 15,
+            "type": "global",
+            "account": "Administrators"
+        },
+        {
+            "mask": 1,
+            "type": "self",
+            "filter": "customer/user eq me()"
+        }
+    ]
+}
+
+describe('CustomQueryExpression', () => {
+
+    let app: TestApplication;
+    let context: DataContext;
+
+    beforeAll(async () => {
+        app = new TestApplication(resolve(process.cwd(), 'spec/test2'));
+        context = app.createContext();
+    });
+
+    afterAll(async () => {
+        await context.finalizeAsync();
+        await app.finalize();
+    });
+
+    it('should change model definition', async () => {
+        await TestUtils.executeInTransaction(context, async () => {
+            const configuration = app.getConfiguration().getStrategy(DataConfigurationStrategy);
+            configuration.setModelDefinition(TempOrderSchema);
+            await context.model('TempOrder').migrateAsync();
+            // insert a temporary object
+            const newOrder: any = {
+                orderDate: new Date(),
+                orderedItem: {
+                    name: 'Samsung Galaxy S4'
+                },
+                customer: {
+                    email: 'luis.nash@example.com'
+                }
+            };
+            await context.model('TempOrder').silent().save(newOrder);
+            const item = await context.model('TempOrder').where('id').equal(newOrder.id).silent().getItem();
+            expect(item).toBeTruthy();
+            expect(item.orderEmail).toEqual('luis.nash@example.com');
+            const orderAddressLocality = await context.model('Person')
+                .where('email').equal('luis.nash@example.com')
+                .select('address/addressLocality').silent().value();
+            expect(item.orderAddressLocality).toEqual(orderAddressLocality);
+
+        });
+    });
+
+    it('should use custom query with expression', async () => {
+        await TestUtils.executeInTransaction(context, async () => {
+            const configuration = app.getConfiguration().getStrategy(DataConfigurationStrategy);
+            configuration.setModelDefinition(NewOrderSchema);
+            await context.model('NewOrder').migrateAsync();
+            // insert a temporary object
+            const newOrder: any = {
+                orderDate: new Date(),
+                orderedItem: {
+                    name: 'Samsung Galaxy S4'
+                },
+                customer: {
+                    email: 'luis.nash@example.com'
+                }
+            };
+            await context.model('NewOrder').silent().save(newOrder);
+            const item = await context.model('NewOrder').where('id').equal(newOrder.id).silent().getItem();
+            expect(item).toBeTruthy();
+            const price = await context.model('Product')
+                .where('name').equal('Samsung Galaxy S4')
+                .select('price').silent().value();
+            expect(item.priceCategory).toEqual(price <= 1000 ? 'Normal' : 'Expensive');
+
+        });
+    });
+
+    it('should use custom query with join expression', async () => {
+        await TestUtils.executeInTransaction(context, async () => {
+            const configuration = app.getConfiguration().getStrategy(DataConfigurationStrategy);
+            configuration.setModelDefinition(NewLocalOrderSchema);
+            await context.model('NewLocalOrder').migrateAsync();
+            // insert a temporary object
+            const newOrder: any = {
+                orderDate: new Date(),
+                orderedItem: {
+                    name: 'Samsung Galaxy S4'
+                },
+                customer: {
+                    email: 'luis.nash@example.com'
+                }
+            };
+            await context.model('NewLocalOrder').silent().save(newOrder);
+            const item = await context.model('NewLocalOrder').where('id').equal(newOrder.id).silent().getItem();
+            expect(item).toBeTruthy();
+            const price = await context.model('Product')
+                .where('name').equal('Samsung Galaxy S4')
+                .select('price').silent().value();
+            expect(item.orderEmail).toEqual('luis.nash@example.com');
+
+        });
+    });
+
+    it('should use custom query to project a readonly attribute', async () => {
+        await TestUtils.executeInTransaction(context, async () => {
+            const configuration = app.getConfiguration().getStrategy(DataConfigurationStrategy);
+            configuration.setModelDefinition(ExtendedProductSchema);
+            const ExtendedProducts = context.model('ExtendedProduct');
+            await ExtendedProducts.migrateAsync();
+            // validate non-insertable columns
+            const db: SqliteAdapter = context.db as SqliteAdapter;
+            const columns = await db.table(ExtendedProducts.sourceAdapter).columnsAsync();
+            expect(columns.find((item) => item.name === 'priceCategory')).toBeFalsy();
+            // insert a temporary object
+            const newProduct: any = {
+                name: 'Samsung Galaxy S4 XL',
+                price: 560,
+                priceCategory: 'Normal'
+            };
+            await context.model('ExtendedProduct').silent().save(newProduct);
+            const item = await context.model('ExtendedProduct').where('id').equal(newProduct.id).silent().getItem();
+            expect(item).toBeTruthy();
+            expect(item.priceCategory).toEqual('Normal');
+
+        });
+    });
+    
+});

--- a/types.d.ts
+++ b/types.d.ts
@@ -146,6 +146,26 @@ export declare class DataAssociationMapping {
   
 }
 
+export declare interface QueryPipelineLookup {
+    from: string;
+    localField?: string;
+    foreignField?: string;
+    let?: string;
+    pipeline?: {
+        $match: any;
+    }
+    as?: string
+}
+
+export declare interface QueryPipelineProject {
+    [name: string]: string | (1 | 0) | any;
+}
+
+export declare interface QueryPipelineStage {
+    $lookup?: QueryPipelineLookup;
+    $project?: QueryPipelineProject;
+}
+
 export declare class DataField {
     name: string;
     property?: string;
@@ -169,6 +189,7 @@ export declare class DataField {
     multiplicity?: string;
     indexed?: boolean;
     size?: number;
+    query?: QueryPipelineStage[];
 }
 
 export declare class DataEventArgs {


### PR DESCRIPTION
This PR implements a feature that has been already supported by `@themost/query@latest` as already has been described by https://github.com/themost-framework/data/pull/87 where an attribute may have a custom query expression before creating the database view object which represents the target model.

e.g. A business process needs customer's email address `customer.email` to be an attribute of an `Order` even if it would be retrieved by expanding `customer`.

Define a readonly attribute `orderEmail`
```
{
    "name": "orderEmail",
    "readonly": true,
    "type": "Text",
    "nullable": true,
    "query": [
        {
            "$lookup": {
                "from": "Person",
                "foreignField": "id",
                "localField": "customer",
                "as": "customer"
            }
        },
        {
            "$project": {
                "orderEmail": "$customer.email"
            }
        }
    ]
}
```
where `orderEmail` has a custom query with two stages:
1. Join `Person` collection based on `customer` attribute of an order.
```
{
    "$lookup": {
        "from": "Person",
        "foreignField": "id",
        "localField": "customer",
        "as": "customer"
    }
}
```
3. Select `customer.email` as part of an order
```
{
    "$project": {
         "orderEmail": "$customer.email"
     }
}
```

The result will be a new extra field based on an SQL statement equivalent to the following one:
```
CREATE VIEW OrderData AS SELECT ..., OrderBase.customer , customer.email AS orderEmail 
     LEFT JOIN PersonData AS customer ON OrderBase.customer = customer.id
```