### PR TITLE
set adapter types as map

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
     - name: npm test
       run: |
         npm ci
-        npx @themost/peers
         npm test
       env:
         CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 17.x, 20.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/data-configuration.d.ts
+++ b/data-configuration.d.ts
@@ -45,6 +45,20 @@ export declare interface AuthSettingsConfiguration {
     loginPage?: string;
 }
 
+export declare type DataAdapterConstructor<T> = Function & { prototype: T };
+
+export declare interface CreateDataAdapterInstance {
+    name: string;
+    invariantName?: string;
+    createInstance?(options: any): any;
+}
+
+export declare interface DataAdapterType {
+    name: string;
+    invariantName?: string;
+    type?: DataAdapterConstructor<any>;
+}
+
 export declare class DataConfiguration {
     constructor(configPath: string);
     static getCurrent(): DataConfiguration;
@@ -58,7 +72,7 @@ export declare class DataConfigurationStrategy extends ConfigurationStrategy{
 
     readonly dataTypes: Map<string, DataTypeConfiguration>;
     readonly adapters: Array<DataAdapterConfiguration>;
-    readonly adapterTypes: Array<DataAdapterTypeConfiguration>;
+    readonly adapterTypes: Map<string, (DataAdapterType | CreateDataAdapterInstance)>;
     getAuthSettings(): AuthSettingsConfiguration;
     getAdapterType(invariantName: string): DataAdapterTypeConfiguration;
     hasDataType(name: string): boolean;

--- a/data-context.js
+++ b/data-context.js
@@ -83,21 +83,27 @@ function DefaultDataContext()
         /**
          * @type {*}
          */
-        var adapterType = strategy.adapterTypes[adapter.invariantName];
+        var adapterType = strategy.adapterTypes.get(adapter.invariantName);
         //validate data adapter type
-        if (_.isNil(adapterType)) {
-            er = new Error('Invalid adapter type.'); er.code = 'EADAPTER';
+        if (adapterType == null) {
+            er = new Error('Invalid adapter type.'); er.code = 'ERR_ADAPTER_TYPE';
             throw er;
         }
-        if (typeof adapterType.createInstance !== 'function') {
-            er= new Error('Invalid adapter type. Adapter initialization method is missing.'); er.code = 'EADAPTER';
-            throw er;
+        // get data adapter instance
+        var createInstance = adapterType.createInstance;
+        // get adapter type constructor if any
+        var AdapterTypeCtor = adapterType.type;
+        // create adapter instance
+        if (typeof  AdapterTypeCtor === 'function') {
+            db_ = new AdapterTypeCtor(adapter.options);
+        } else if (typeof createInstance === 'function') {
+            db_ = createInstance(adapter.options);
+        } else {
+            // throw error
+            var err = new Error('The given adapter type is invalid. Adapter type constructor is undefined.');
+            err.code = 'ERR_ADAPTER_TYPE';
+            throw err;
         }
-        //otherwise load adapter
-        /**
-         * @type {DataAdapter|*}
-         */
-        db_ = adapterType.createInstance(adapter.options);
         if (typeof db_.hasConfiguration === 'function') {
             db_.hasConfiguration(function() {
                return self.getConfiguration();
@@ -238,18 +244,22 @@ function NamedDataContext(name)
             throw er;
         }
         //get data adapter type
-        var adapterType = strategy.adapterTypes[adapter.invariantName];
-        //validate data adapter type
-        if (_.isNil(adapterType)) {
-            er = new Error('Invalid adapter type.'); er.code = 'EADAPTER';
-            throw er;
+        var adapterType = strategy.adapterTypes.get(adapter.invariantName);
+        // get data adapter instance
+        var createInstance = adapterType.createInstance;
+        // get adapter type constructor if any
+        var AdapterTypeCtor = adapterType.type;
+        // create adapter instance
+        if (typeof  AdapterTypeCtor === 'function') {
+            db_ = new AdapterTypeCtor(adapter.options);
+        } else if (typeof createInstance === 'function') {
+            db_ = createInstance(adapter.options);
+        } else {
+            // throw error
+            var err = new Error('The given adapter type is invalid. Adapter type constructor is undefined.');
+            err.code = 'ERR_ADAPTER_TYPE';
+            throw err;
         }
-        if (typeof adapterType.createInstance !== 'function') {
-            er= new Error('Invalid adapter type. Adapter initialization method is missing.'); er.code = 'EADAPTER';
-            throw er;
-        }
-        //otherwise load adapter
-        db_ = adapterType.createInstance(adapter.options);
         if (typeof db_.hasConfiguration === 'function') {
             db_.hasConfiguration(function() {
                 return self.getConfiguration();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.14.2",
+      "version": "2.14.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@babel/preset-typescript": "^7.16.7",
         "@themost/common": "^2.10.4",
         "@themost/peers": "^1.0.2",
-        "@themost/query": "^2.14.1",
+        "@themost/query": "^2.14.6",
         "@themost/sqlite": "^2.6.16",
         "@themost/xml": "^2.5.2",
         "@types/core-js": "^2.5.0",
@@ -2972,10 +2972,11 @@
       "integrity": "sha512-flTqKuFh1k9JXccwoUskHSjSG81tu0Di/kraNap6dcoQMZyDEgcT9AICu6tyPidWbMilf0bXg5gW1gRjQl5Yiw=="
     },
     "node_modules/@themost/query": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.14.1.tgz",
-      "integrity": "sha512-hfLT/hAU7iHpcI6o5i3IjpGgsUyzX19bz3mSY0NojT2W4Y4rWe8f19UCF6cfWYdHQjPhZIVFHxxTaPhP0DumoA==",
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.14.6.tgz",
+      "integrity": "sha512-iZvGPZtFkxGqSrTXpOk1qQSid77F0gF0M0OICpTYnjDBEv6Be7J2n+UZ6wK05rUO5uL+tnUrGVaHpj1GzDhXWg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",
         "async": "^3.2.3",
@@ -7513,12 +7514,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@babel/preset-typescript": "^7.16.7",
         "@themost/common": "^2.10.4",
         "@themost/peers": "^1.0.2",
-        "@themost/query": "^2.14.6",
+        "@themost/query": "^2.14.7",
         "@themost/sqlite": "^2.6.16",
         "@themost/xml": "^2.5.2",
         "@types/core-js": "^2.5.0",
@@ -2972,9 +2972,9 @@
       "integrity": "sha512-flTqKuFh1k9JXccwoUskHSjSG81tu0Di/kraNap6dcoQMZyDEgcT9AICu6tyPidWbMilf0bXg5gW1gRjQl5Yiw=="
     },
     "node_modules/@themost/query": {
-      "version": "2.14.6",
-      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.14.6.tgz",
-      "integrity": "sha512-iZvGPZtFkxGqSrTXpOk1qQSid77F0gF0M0OICpTYnjDBEv6Be7J2n+UZ6wK05rUO5uL+tnUrGVaHpj1GzDhXWg==",
+      "version": "2.14.7",
+      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.14.7.tgz",
+      "integrity": "sha512-VpW6ad64IRVHk+wY+FINbppblushOGIOb9TCwcNfr930o82IjTMhbOkGnIM2hx3x68T3iWoK0YiGaZxegAfWkg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/preset-typescript": "^7.16.7",
     "@themost/common": "^2.10.4",
     "@themost/peers": "^1.0.2",
-    "@themost/query": "^2.14.1",
+    "@themost/query": "^2.14.6",
     "@themost/sqlite": "^2.6.16",
     "@themost/xml": "^2.5.2",
     "@types/core-js": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/preset-typescript": "^7.16.7",
     "@themost/common": "^2.10.4",
     "@themost/peers": "^1.0.2",
-    "@themost/query": "^2.14.6",
+    "@themost/query": "^2.14.7",
     "@themost/sqlite": "^2.6.16",
     "@themost/xml": "^2.5.2",
     "@types/core-js": "^2.5.0",

--- a/spec/DataApplication.spec.ts
+++ b/spec/DataApplication.spec.ts
@@ -65,7 +65,8 @@ describe('DataApplication', () => {
         expect(context).toBeTruthy();
         const Products = context.model('Product');
         expect(Products).toBeTruthy();
-        await context.finalize();
+        await context.finalizeAsync();
         await TestUtils.finalize(app);
     });
+
 });

--- a/spec/TestApplication.ts
+++ b/spec/TestApplication.ts
@@ -38,7 +38,7 @@ export class TestApplication extends IApplication {
             {
                 'name':'Test Data Adapter', 
                 'invariantName': 'test',
-                'type': '@themost/sqlite'
+                'type': '@themost/sqlite#SqliteAdapter'
             }
         ]);
         const db = resolve(__dirname, 'test1/db', 'test.db');


### PR DESCRIPTION
This PR changes `DataConfigurationStrategy.adapterTypes` type definition to be a `Map<string,DataAdapterType>`. This operation is useful for defining adapter types at runtime instead of using an application configuration file e.g.

```javascript
const app = new DataApplication(process.cwd());
const configuration = app.configuration.getStrategy(DataConfigurationStrategy);
// add sqlite adapter type
configuration.adapterTypes.set('sqlite', {
    name: 'sqlite',
    type: SqliteAdapter
});
// add test adapter type
configuration.adapters.push({
    default: true,
    invariantName: 'sqlite',
    name: 'development',
    options: {
        database: ':memory:'
    }
});
```