### PR TITLE
Unregister context listeners before set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.6.60",
+  "version": "2.6.61",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.6.60",
+      "version": "2.6.61",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.6.61",
+  "version": "2.6.62",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.6.61",
+      "version": "2.6.62",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.61",
+  "version": "2.6.62",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.60",
+  "version": "2.6.61",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This pull request updates `DataModel.context` property to forcibly unregister existing listeners before setting value.