### PR TITLE
unregister listeners before setting context

### DIFF
--- a/data-model.js
+++ b/data-model.js
@@ -282,7 +282,7 @@ function DataModel(obj) {
      * @type {DataContext}
      * @private
      */
-    var context_ = null;
+    var context = null;
     var self = this;
 
     /**
@@ -290,17 +290,18 @@ function DataModel(obj) {
      * @type {DataContext|*}
      */
 
-    Object.defineProperty(this, 'context', { get: function() {
-        return context_;
-    }, set: function(value) {
-        context_ = value;
-        if (_.isNil(context_)) {
-            unregisterContextListeners.bind(this)();
-        }
-        else {
-            registerContextListeners.bind(this)();
-        }
-    }, enumerable: false, configurable: false});
+    Object.defineProperty(this, 'context', {
+        get: function () {
+            return context;
+        }, set: function (value) {
+            context = value;
+            // unregister listeners
+            unregisterContextListeners.call(self);
+            if (context != null) {
+                registerContextListeners.call(self);
+            }
+        }, enumerable: false, configurable: false
+    });
 
     /**
      * @description Gets the database object associated with this data model
@@ -594,6 +595,7 @@ function unregisterContextListeners() {
     this.removeAllListeners('after.remove');
     this.removeAllListeners('before.execute');
     this.removeAllListeners('after.execute');
+    this.removeAllListeners('before.upgrade');
     this.removeAllListeners('after.upgrade');
 }
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.15.0",
+      "version": "2.15.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.15.0",
+  "version": "2.15.1",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This pull requests update `DataMode.context` property and forcibly unregisters listeners before setting context. 