### PR TITLE
bump node-cache to 5.1.2

### DIFF
--- a/data-cache.d.ts
+++ b/data-cache.d.ts
@@ -1,42 +1,25 @@
 // MOST Web Framework 2.0 Codename Blueshift BSD-3-Clause license Copyright (c) 2017-2022, THEMOST LP All rights reserved
 import {ConfigurationStrategy} from "@themost/common";
 
-
 export declare interface DataCacheStrategyBase {
     add(key: string, value: any, absoluteExpiration?: number): Promise<any>;
     remove(key: string): Promise<any>;
-    clear(): Promise<any>;
-    get(key: string): Promise<any>;
-    getOrDefault(key: string, getFunc: Promise<any>, absoluteExpiration?: number): Promise<any>;
+    clear(): Promise<void>;
+    get<T>(key: string): Promise<T>;
+    getOrDefault<T>(key: string, getFunc: () => Promise<T>, absoluteExpiration?: number): Promise<T>;
 }
 
 export declare interface DataCacheFinalize extends DataCacheStrategyBase {
     finalize(): Promise<void>;
 }
 
-export declare class DataCache {
-    init(callback: (err?: Error) => void): void;
-
-    remove(key: string, callback: (err?: Error) => void): void;
-
-    removeAll(callback: (err?: Error) => void): void;
-
-    add(key: string, value: any, ttl?: number, callback?: (err?: Error) => void): void;
-
-    ensure(key: string, getFunc: (err?: Error, res?: any) => void, callback?: (err?: Error) => void): void;
-
-    get(key: string, callback?: (err?: Error, res?: any) => void): void;
-
-    static getCurrent(): DataCache;
-}
-
 export declare abstract class DataCacheStrategy extends ConfigurationStrategy implements DataCacheStrategyBase {
 
     abstract add(key: string, value: any, absoluteExpiration?: number): Promise<any>;
     abstract remove(key: string): Promise<any>;
-    abstract clear(): Promise<any>;
-    abstract get(key: string): Promise<any>;
-    abstract getOrDefault(key: string, getFunc: Promise<any>, absoluteExpiration?: number): Promise<any>;
+    abstract clear(): Promise<void>;
+    abstract get<T>(key: string): Promise<T>;
+    abstract getOrDefault<T>(key: string, getFunc: () => Promise<T>, absoluteExpiration?: number): Promise<T>;
 
 }
 
@@ -44,9 +27,9 @@ export declare class DefaultDataCacheStrategy extends DataCacheStrategy implemen
 
     add(key: string, value: any, absoluteExpiration?: number): Promise<any>;
     remove(key: string): Promise<any>;
-    clear(): Promise<any>;
-    get(key: string): Promise<any>;
-    getOrDefault(key: string, getFunc: Promise<any>, absoluteExpiration?: number): Promise<any>;
+    clear(): Promise<void>;
+    get<T>(key: string): Promise<T>;
+    getOrDefault<T>(key: string, getFunc: () => Promise<T>, absoluteExpiration?: number): Promise<T>;
     finalize(): Promise<void>;
 
 }

--- a/data-cache.js
+++ b/data-cache.js
@@ -1,443 +1,207 @@
 // MOST Web Framework 2.0 Codename Blueshift BSD-3-Clause license Copyright (c) 2017-2022, THEMOST LP All rights reserved
-var _ = require('lodash');
-var {LangUtils, Args, SequentialEventEmitter, AbstractMethodError, ConfigurationStrategy} = require('@themost/common');
-var {hasOwnProperty} = require('./has-own-property');
-var Symbol = require('symbol');
-var Q = require('q');
-var currentProperty = Symbol('current');
+var {LangUtils, Args, AbstractMethodError, ConfigurationStrategy} = require('@themost/common');
 var CACHE_ABSOLUTE_EXPIRATION = 1200;
 
-/**
- * @class
- * @classdesc Implements data cache mechanisms in MOST Data Applications.
- * DataCache class is used as the internal data caching engine, if any other caching mechanism is not defined.
- * @property {Number} ttl - An amount of time in seconds which is the default cached item lifetime.
- * @constructor
- * @augments SequentialEventEmitter
- * @deprecated
- */
-function DataCache() {
-    // noinspection JSUnusedGlobalSymbols
-    this.initialized = false;
+
+
+class DataCacheStrategy extends ConfigurationStrategy {
+    /**
+     *
+     * @param {import('@themost/common').ConfigurationBase} config
+     * @constructor
+     *
+     */
+    constructor(config) {
+        super(config);
+    }
+
+    /**
+     * Sets a key value pair in cache.
+     * @abstract
+     * @param {string} key - A string that represents the key of the cached value
+     * @param {*} value - The value to be cached
+     * @param {number=} absoluteExpiration - An absolute expiration time in seconds. This parameter is optional.
+     * @returns {Promise|*}
+     */
+    // eslint-disable-next-line no-unused-vars
+    add(key, value, absoluteExpiration) {
+        throw new AbstractMethodError();
+    }
+
+    /**
+     * Removes a cached value.
+     * @abstract
+     * @param {string} key - A string that represents the key of the cached value to be removed
+     * @returns {Promise|*}
+     */
+    // eslint-disable-next-line no-unused-vars
+    remove(key) {
+        throw new AbstractMethodError();
+    }
+
+    /**
+     * Flush all cached data.
+     * @abstract
+     * @returns {Promise|*}
+     */
+    clear() {
+        throw new AbstractMethodError();
+    }
+
+    // noinspection JSUnusedLocalSymbols
+    /**
+     * Gets a cached value defined by the given key.
+     * @param {string} key
+     * @returns {Promise|*}
+     */
+    // eslint-disable-next-line no-unused-vars
+    get(key) {
+        throw new AbstractMethodError();
+    }
+
+    // noinspection JSUnusedLocalSymbols
+    /**
+     * Gets data from cache or executes the defined function and adds the result to the cache with the specified key
+     * @param {string|*} key - A string which represents the key of the cached data
+     * @param {Function} getFunc - A function to execute if data will not be found in cache
+     * @param {number=} absoluteExpiration - An absolute expiration time in seconds. This parameter is optional.
+     * @returns {Promise|*}
+     */
+    // eslint-disable-next-line no-unused-vars
+    getOrDefault(key, getFunc, absoluteExpiration) {
+        throw new AbstractMethodError();
+    }
 }
-LangUtils.inherits(DataCache, SequentialEventEmitter);
-/**
- * Initializes data caching.
- * @param {Function} callback - A callback function where the first argument will contain the Error object if an error occurred, or null otherwise.
- *
- * @example
- var d = require("most-data");
- //try to find article with id 100 in cache
- d.cache.current.init(function(err) {
-    done(err);
- };
- */
-DataCache.prototype.init = function(callback) {
-    try {
-        if (this.initialized) {
-            callback();
-            return;
-        }
+
+class DefaultDataCacheStrategy extends DataCacheStrategy {
+    /**
+     *
+     * @param {import('@themost/common').ConfigurationBase} config
+     * @constructor
+     *
+     */
+    constructor(config) {
+        super(config);
         var NodeCache = require( 'node-cache' );
-        this.rawCache = new NodeCache();
-        this.initialized = true;
-        callback();
+        var expiration = CACHE_ABSOLUTE_EXPIRATION;
+        var absoluteExpiration = LangUtils.parseInt(config.getSourceAt('settings/cache/absoluteExpiration'));
+        if (absoluteExpiration>0) {
+            expiration = absoluteExpiration;
+        }
+        this.rawCache = new NodeCache({
+            stdTTL:expiration
+        });
     }
-    catch (e) {
-        callback(e);
-    }
-};
 
-/**
- * Removes a cached value.
- * @param {string} key - A string that represents the key of the cached value
- * @param {function(Error=)=} callback - A callback function where the first argument will contain the Error object if an error occurred, or null otherwise.
- *
- * @example
- var d = require("most-data");
- //try to find article with id 100 in cache
- d.cache.current.remove('/Article/100', function(err) {
-    done(err);
- };
- */
-DataCache.prototype.remove = function(key, callback) {
-    var self = this;
-    callback = callback || function() {};
-    self.init(function(err) {
-        if (err) {
-            callback(err);
-        }
-        else {
-            self.rawCache.set(key, callback);
-        }
-    });
-};
-
-/**
- * Flush all cached data.
- * @param {function(Error=)=} callback - A callback function where the first argument will contain the Error object if an error occurred, or null otherwise.
- *
- * @example
- var d = require("most-data");
- //try to find article with id 100 in cache
- d.cache.current.removeAll(function(err) {
-    done(err);
- };
- */
-DataCache.prototype.removeAll = function(callback) {
-    var self = this;
-    callback = callback || function() {};
-    self.init(function(err) {
-        if (err) {
-            callback(err);
-        }
-        else {
-            self.rawCache.flushAll();
-            callback();
-        }
-    });
-};
-
-/**
- * Sets a key value pair in cache.
- * @param {string} key - A string that represents the key of the cached value
- * @param {*} value - The value to be cached
- * @param {number=} ttl - A TTL in seconds. This parameter is optional.
- * @param {Function=} callback - A callback function where the first argument will contain the Error object if an error occurred and the second argument will return true on success.
- *
- * @example
- var d = require("most-data");
- d.cache.current.add('/User/100', { "id":100,"name":"user1@example.com","description":"User #1" }, 1200, function(err) {
-    done(err);
- });
- */
-DataCache.prototype.add = function(key, value, ttl, callback) {
-    var self = this;
-    callback = callback || function() {};
-    self.init(function(err) {
-        if (err) {
-            callback(err);
-        }
-        else {
-            self.rawCache.set(key, value, ttl, callback);
-        }
-    });
-};
-/**
- * Gets data from cache or executes the defined function and adds the result to the cache with the specified key
- * @param {string|*} key - A string that represents the of the cached data
- * @param {function(function(Error=,*=))} fn - A function to execute if data will not be found in cache
- * @param {function(Error=,*=)} callback - A callback function where the first argument will contain the Error object if an error occurred and the second argument will contain the result.
- * @example
- var d = require("most-data");
- //try to find user with id 100 in cache
- d.cache.current.ensure('/User/100', function(cb) {
-        //otherwise get user from database
-      context.model('User').where('id').equal(100).first().then(function(result) {
-        cb(null, result);
-      }).catch(function(err) {
-        cb(err);
-      }
- }, function(err, result) {
-    //and finally return the result
-    done(err,result);
- };
- */
-DataCache.prototype.ensure = function(key, fn, callback) {
-    var self = this;
-    callback = callback || function() {};
-    if (typeof fn !== 'function') {
-        callback(new Error('Invalid argument. Expected function.'));
-        return;
-    }
-    //try to get from cache
-    self.get(key, function(err, result) {
-        if (err) { callback(err); return; }
-        if (typeof result !== 'undefined') {
-            callback(null, result);
-        }
-        else {
-            //execute fn
-            fn(function(err, result) {
-                if (err) { callback(err); return; }
-                self.add(key, (typeof result === 'undefined') ? null: result, self.ttl, function() {
-                    callback(null, result);
-                });
-            });
-        }
-    });
-};
-/**
- * Gets a cached value defined by the given key.
- * @param {string|*} key - A string that represents the key of the cached value
- * @param {function(Error=,*=)} callback - A callback function where the first argument will contain the Error object if an error occurred and the second argument will contain the result.
- *
- * @example
- var d = require("most-data");
- //try to find article with id 100 in cache
- d.cache.current.get('/Article/100', function(err, result) {
-    done(err,result);
- };
- */
-DataCache.prototype.get = function(key, callback) {
-    var self = this;
-    callback = callback || function() {};
-    if (_.isNil(key)) {
-        return callback();
-    }
-    self.init(function(err) {
-        if (err) {
-            callback(err);
-        }
-        else {
-            self.rawCache.get(key, function(err, value) {
-                if (err) {
-                    callback(err);
-                }
-                else {
-                    if (typeof value[key] !== 'undefined') {
-                        callback(null, value[key]);
-                    }
-                    else {
-                        callback();
-                    }
-                }
-            });
-        }
-    });
-};
-/**
- * @returns DataCache
- */
-DataCache.getCurrent = function() {
-    if (typeof global !== 'undefined' || global !== null) {
-        var app = global.application;
-        if (app) {
-            //and if this application has a cache object
-            if (app.cache) {
-                //use this cache
-                return app.cache;
+    /**
+     * Sets a key value pair in cache.
+     * @param {string} key - A string that represents the key of the cached value
+     * @param {*} value - The value to be cached
+     * @param {number=} absoluteExpiration - An absolute expiration time in seconds. This parameter is optional.
+     * @returns {Promise|*}
+     */
+    add(key, value, absoluteExpiration) {
+        var self = this;
+        return new Promise(function(resolve, reject) {
+            try {
+                self.rawCache.set(key, value, absoluteExpiration);
+                return resolve();
+            } catch (err) {
+                return reject(err);
             }
-        }
+        });
     }
-    if (DataCache[currentProperty]) {
-        return DataCache[currentProperty];
+
+    /**
+     * Gets a cached value defined by the given key.
+     * @param {string} key
+     * @returns {Promise|*}
+     */
+    get(key) {
+        var self = this;
+        return new Promise(function(resolve, reject) {
+            try {
+                var res = self.rawCache.get(key);
+                return resolve(res);
+            } catch (err) {
+                return reject(err);
+            }
+        });
     }
-    DataCache[currentProperty] = new DataCache();
-    return DataCache[currentProperty];
-};
 
-/**
- *
- * @param {ConfigurationBase} config
- * @constructor
- *
- */
-function DataCacheStrategy(config) {
-    DataCacheStrategy.super_.bind(this)(config);
-}
-LangUtils.inherits(DataCacheStrategy, ConfigurationStrategy);
-
-/**
- * Sets a key value pair in cache.
- * @abstract
- * @param {string} key - A string that represents the key of the cached value
- * @param {*} value - The value to be cached
- * @param {number=} absoluteExpiration - An absolute expiration time in seconds. This parameter is optional.
- * @returns {Promise|*}
- */
-// eslint-disable-next-line no-unused-vars
-DataCacheStrategy.prototype.add = function(key, value, absoluteExpiration) {
-    throw new AbstractMethodError();
-};
-
-/**
- * Removes a cached value.
- * @abstract
- * @param {string} key - A string that represents the key of the cached value to be removed
- * @returns {Promise|*}
- */
-// eslint-disable-next-line no-unused-vars
-DataCacheStrategy.prototype.remove = function(key) {
-    throw new AbstractMethodError();
-};
-/**
- * Flush all cached data.
- * @abstract
- * @returns {Promise|*}
- */
-DataCacheStrategy.prototype.clear = function() {
-    throw new AbstractMethodError();
-};
-/**
- * Gets a cached value defined by the given key.
- * @param {string} key
- * @returns {Promise|*}
- */
-// eslint-disable-next-line no-unused-vars
-DataCacheStrategy.prototype.get = function(key) {
-    throw new AbstractMethodError();
-};
-/**
- * Gets data from cache or executes the defined function and adds the result to the cache with the specified key
- * @param {string|*} key - A string which represents the key of the cached data
- * @param {Function} getFunc - A function to execute if data will not be found in cache
- * @param {number=} absoluteExpiration - An absolute expiration time in seconds. This parameter is optional.
- * @returns {Promise|*}
- */
-// eslint-disable-next-line no-unused-vars
-DataCacheStrategy.prototype.getOrDefault = function(key, getFunc, absoluteExpiration) {
-    throw new AbstractMethodError();
-};
-
-/**
- *
- * @param {ConfigurationBase} config
- * @constructor
- *
- */
-function DefaultDataCacheStrategy(config) {
-    DefaultDataCacheStrategy.super_.bind(this)(config);
-    var NodeCache = require( 'node-cache' );
-    var expiration = CACHE_ABSOLUTE_EXPIRATION;
-    var absoluteExpiration = LangUtils.parseInt(config.getSourceAt('settings/cache/absoluteExpiration'));
-    if (absoluteExpiration>0) {
-        expiration = absoluteExpiration;
+    /**
+     * Removes a cached value.
+     * @param {string} key - A string that represents the key of the cached value to be removed
+     * @returns {Promise|*}
+     */
+    remove(key) {
+        var self = this;
+        return new Promise(function(resolve, reject) {
+            try {
+                self.rawCache.del(key);
+                return resolve();
+            } catch (err) {
+                return reject(err);
+            }
+        });
     }
-    this.rawCache = new NodeCache({
-        stdTTL:expiration
-    });
-}
-LangUtils.inherits(DefaultDataCacheStrategy, DataCacheStrategy);
 
-/**
- * Sets a key value pair in cache.
- * @param {string} key - A string that represents the key of the cached value
- * @param {*} value - The value to be cached
- * @param {number=} absoluteExpiration - An absolute expiration time in seconds. This parameter is optional.
- * @returns {Promise|*}
- */
-// eslint-disable-next-line no-unused-vars
-DefaultDataCacheStrategy.prototype.add = function(key, value, absoluteExpiration) {
-    var self = this;
-    return Q.Promise(function(resolve, reject) {
-        self.rawCache.set(key, value, absoluteExpiration, function(err) {
-            if (err) {
+    /**
+     * Flush all cached data.
+     * @returns {Promise|*}
+     */
+    clear() {
+        var self = this;
+        return new Promise(function(resolve, reject) {
+            try {
+                self.rawCache.flushAll();
+            } catch (err) {
                 return reject(err);
             }
             return resolve();
         });
-    });
-};
+    }
 
-/**
- * Gets a cached value defined by the given key.
- * @param {string} key
- * @returns {Promise|*}
- */
-// eslint-disable-next-line no-unused-vars
-DefaultDataCacheStrategy.prototype.get = function(key) {
-    var self = this;
-    return Q.Promise(function(resolve, reject) {
-        self.rawCache.get(key, function(err, res) {
-            if (err) {
-                return reject(err);
+    finalize() {
+        var self = this;
+        return self.clear().then(function() {
+            // destroy timer
+            if (self.rawCache) {
+                self.rawCache.close();
             }
-            return resolve(res[key]);
         });
-    });
-};
+    }
 
-/**
- * Removes a cached value.
- * @param {string} key - A string that represents the key of the cached value to be removed
- * @returns {Promise|*}
- */
-// eslint-disable-next-line no-unused-vars
-DefaultDataCacheStrategy.prototype.remove = function(key) {
-    var self = this;
-    return Q.Promise(function(resolve, reject) {
-        self.rawCache.del(key, function(err, count) {
-            if (err) {
-                return reject(err);
-            }
-            return resolve(count);
-        });
-    });
-};
-
-/**
- * Flush all cached data.
- * @returns {Promise|*}
- */
-DefaultDataCacheStrategy.prototype.clear = function() {
-    var self = this;
-    return Q.Promise(function(resolve, reject) {
-        try {
-            self.rawCache.flushAll();
-        } catch (err) {
-            return reject(err);
-        }
-        return resolve();
-    });
-};
-
-DefaultDataCacheStrategy.prototype.finalize = function() {
-    var self = this;
-    return self.clear().then(function() {
-        // destroy timer
-        if (self.rawCache && typeof self.rawCache._killCheckPeriod === 'function') {
-            self.rawCache._killCheckPeriod();
-        }
-    });
-}
-
-/**
- * Gets data from cache or executes the defined function and adds the result to the cache with the specified key
- * @param {string|*} key - A string which represents the key of the cached data
- * @param {Function} getFunc - A function to execute if data will not be found in cache
- * @param {number=} absoluteExpiration - An absolute expiration time in seconds. This parameter is optional.
- * @returns {Promise|*}
- */
-// eslint-disable-next-line no-unused-vars
-DefaultDataCacheStrategy.prototype.getOrDefault = function(key, getFunc, absoluteExpiration) {
-    var self = this;
-    return Q.Promise(function(resolve, reject) {
-        //try to get from cache
-        self.rawCache.get(key, function(err, result) {
-            if (err) {
-                return reject(err);
-            }
-            else if (typeof result !== 'undefined' && hasOwnProperty(result, key)) {
-                return resolve(result[key]);
-            }
-            else {
-                try {
-                    //execute function and validate promise
-                    var source = getFunc();
-                    Args.check(typeof source !== 'undefined' && typeof source.then === 'function', 'Invalid argument. Expected a valid promise.');
-                    return source.then(function (res) {
-                        if (_.isNil(res)) {
-                            return resolve();
-                        }
-                        return self.rawCache.set(key, res, absoluteExpiration, function (err) {
-                            if (err) {
-                                return reject(err);
-                            }
-                            return resolve(res);
-                        });
-                    })
-                    .catch(function(err) {
+    /**
+     * Gets data from cache or executes the defined function and adds the result to the cache with the specified key
+     * @param {string|*} key - A string which represents the key of the cached data
+     * @param {Function} getFunc - A function to execute if data will not be found in cache
+     * @param {number=} absoluteExpiration - An absolute expiration time in seconds. This parameter is optional.
+     * @returns {Promise|*}
+     */
+    getOrDefault(key, getFunc, absoluteExpiration) {
+        var self = this;
+        return new Promise(function(resolve, reject) {
+            //try to get from cache
+            try {
+                if (self.rawCache.has(key)) {
+                    return resolve(self.rawCache.get(key));
+                }
+                var source = getFunc();
+                Args.check(typeof source !== 'undefined' && typeof source.then === 'function', 'Invalid argument. Expected a valid promise.');
+                void source.then(function (res) {
+                    self.rawCache.set(key, res, absoluteExpiration);
+                    return resolve(res);
+                }).catch(function(err) {
                         return reject(err);
                     });
-                }
-                catch(err) {
-                    return reject(err);
-                }
+
+            } catch (err) {
+                return reject(err);
             }
         });
-    });
-};
+    }
+}
 
 module.exports = {
     DataCacheStrategy,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@themost/promise-sequence": "^1.0.1",
         "async": "^2.6.4",
         "lodash": "^4.17.21",
-        "node-cache": "^1.1.0",
+        "node-cache": "^5.1.2",
         "pluralize": "^7.0.0",
         "q": "^1.4.1",
         "sprintf-js": "^1.1.2",
@@ -6178,6 +6178,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6349,10 +6358,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -7899,6 +7909,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10592,14 +10603,15 @@
       }
     },
     "node_modules/node-cache": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-1.1.0.tgz",
-      "integrity": "sha1-GGNlAy0jlb3/c0BBePsryJgaznA=",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
       "dependencies": {
-        "underscore": "*"
+        "clone": "2.x"
       },
       "engines": {
-        "node": ">= 0.4.6"
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/node-gyp": {
@@ -11869,11 +11881,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/underscore": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.3.tgz",
-      "integrity": "sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA=="
-    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -12976,8 +12983,7 @@
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
       "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -16294,8 +16300,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "agent-base": {
       "version": "6.0.2",
@@ -16795,6 +16800,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -16930,9 +16940,9 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -16968,8 +16978,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
       "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -18862,8 +18871,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "29.6.3",
@@ -20125,11 +20133,11 @@
       "dev": true
     },
     "node-cache": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-1.1.0.tgz",
-      "integrity": "sha1-GGNlAy0jlb3/c0BBePsryJgaznA=",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
       "requires": {
-        "underscore": "*"
+        "clone": "2.x"
       }
     },
     "node-gyp": {
@@ -21053,11 +21061,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
       "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
-    },
-    "underscore": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.3.tgz",
-      "integrity": "sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.6.62",
+  "version": "2.6.63",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.6.62",
+      "version": "2.6.63",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.62",
+  "version": "2.6.63",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@themost/promise-sequence": "^1.0.1",
     "async": "^2.6.4",
     "lodash": "^4.17.21",
-    "node-cache": "^1.1.0",
+    "node-cache": "^5.1.2",
     "pluralize": "^7.0.0",
     "q": "^1.4.1",
     "sprintf-js": "^1.1.2",

--- a/spec/DataCacheStrategy.spec.ts
+++ b/spec/DataCacheStrategy.spec.ts
@@ -1,0 +1,118 @@
+import {resolve} from 'path';
+import {DataCacheStrategy, DataContext} from '../index';
+import {TestApplication} from './TestApplication';
+
+describe('DataCacheStrategy', () => {
+    let app: TestApplication;
+    let context: DataContext;
+    beforeAll(async () => {
+        app = new TestApplication(resolve(__dirname, 'test2'));
+        context = app.createContext();
+    });
+    afterAll(async () => {
+        await context.finalizeAsync();
+        await app.finalize();
+    });
+
+    afterEach(async () => {
+        const cache = app.getConfiguration().getStrategy(DataCacheStrategy);
+        await cache.clear();
+    })
+
+    it('should get cached item', async () => {
+        const cache = app.getConfiguration().getStrategy(DataCacheStrategy);
+        expect(cache).toBeTruthy();
+        let value = await cache.get<{message: string}>('test-key');
+        expect(value).toBeUndefined();
+        await cache.add('test-key', {
+            message: 'Hello World'
+        });
+        value = await cache.get<{message: string}>('test-key');
+        expect(value).toBeTruthy();
+        expect(value.message).toBe('Hello World');
+    });
+
+    it('should remove cached item', async () => {
+        const cache = app.getConfiguration().getStrategy(DataCacheStrategy);
+        expect(cache).toBeTruthy();
+        let value = await cache.get('test-key');
+        expect(value).toBeUndefined();
+        await cache.add('test-key', {
+            message: 'Hello World'
+        });
+        await cache.remove('test-key');
+        value = await cache.get('test-key');
+        expect(value).toBeUndefined();
+    });
+
+    it('should use absolute expiration', async () => {
+        const cache = app.getConfiguration().getStrategy(DataCacheStrategy);
+        expect(cache).toBeTruthy();
+        await cache.add('test-key', {
+            message: 'Hello World'
+        }, 1);
+        let value = await cache.get('test-key');
+        expect(value).toBeTruthy();
+        // wait for 2 seconds
+        await new Promise((resolve) => setTimeout(() => {
+            return resolve(void 0);
+        }, 2000));
+        value = await cache.get('test-key');
+        expect(value).toBeUndefined();
+    });
+
+    it('should clear cache', async () => {
+        const cache = app.getConfiguration().getStrategy(DataCacheStrategy);
+        expect(cache).toBeTruthy();
+        await cache.add('test-key-1', {
+            message: 'Hello World'
+        });
+        await cache.add('test-key-2', {
+            message: 'Hello World!'
+        });
+        let value = await cache.get('test-key-1');
+        expect(value).toBeTruthy();
+        await cache.clear();
+        value = await cache.get('test-key-1');
+        expect(value).toBeUndefined();
+        value = await cache.get('test-key-2');
+        expect(value).toBeUndefined();
+    });
+
+    it('should get default value', async () => {
+        const cache = app.getConfiguration().getStrategy(DataCacheStrategy);
+        await cache.getOrDefault<{ message: string }>('test-key-1', async () => {
+            return {
+                message: 'Hello World'
+            }
+        });
+        const value = await cache.get<{message: string}>('test-key-1');
+        expect(value).toBeTruthy();
+        expect(value.message).toEqual('Hello World');
+    });
+
+    it('should get default null value', async () => {
+        const cache = app.getConfiguration().getStrategy(DataCacheStrategy);
+        const getValue: () => Promise<any> = async () => {
+            return null;
+        };
+        await cache.getOrDefault<any>('test-key-1', getValue);
+        let value = await cache.get('test-key-1');
+        expect(value).toBeNull();
+    });
+
+    it('should get default value once', async () => {
+        const cache = app.getConfiguration().getStrategy(DataCacheStrategy);
+        let counter = 0;
+        await cache.getOrDefault<any>('test-key-1', async () => {
+            counter++;
+            return counter;
+        });
+        let value = await cache.get('test-key-1');
+        expect(value).toEqual(1);
+        counter++;
+        value = await cache.get('test-key-1');
+        expect(value).toEqual(1);
+    });
+
+});


### PR DESCRIPTION
This PR bumps node-cache to 5.1.2 and migrates `DataCacheStrategy` to use the new version of `NodeCache`.