### PR TITLE
fix DataModel.clone()

### DIFF
--- a/data-model.js
+++ b/data-model.js
@@ -1,5 +1,6 @@
 // MOST Web Framework 2.0 Codename Blueshift BSD-3-Clause license Copyright (c) 2017-2022, THEMOST LP All rights reserved
 var _ = require('lodash');
+var {cloneDeep} = require('lodash');
 var {sprintf} = require('sprintf-js');
 var Symbol = require('symbol');
 var pluralize = require('pluralize');
@@ -578,10 +579,11 @@ DataModel.prototype.initialize = function() {
  * @returns {DataModel} Returns a new DataModel instance
  */
 DataModel.prototype.clone = function(context) {
-    var result = new DataModel(this);
-    if (context)
-        result.context = context;
-    return result;
+    // create new instance
+    var cloned = new DataModel(cloneDeep(this)).silent(this.isSilent());
+    // set context or this model context
+    cloned.context = context || this.context;
+    return cloned;
 };
 /**
  * @this DataModel

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.16.1",
+      "version": "2.16.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/spec/DataModel.spec.ts
+++ b/spec/DataModel.spec.ts
@@ -94,4 +94,16 @@ describe('DataModel', () => {
         expect(model.caching).toBe('none');
     });
 
+    it('should clone model', () => {
+        const model = context.model('Employee').silent();
+        expect(model).toBeTruthy();
+        const cloned = model.clone();
+        expect(cloned instanceof DataModel);
+        expect(cloned.name).toEqual(model.name);
+        // change something to parent
+        model.caching = 'always';
+        expect(cloned.caching).not.toBe(model.caching);
+        expect(cloned.isSilent()).toBeTruthy();
+    });
+
 });


### PR DESCRIPTION
This PR updates `DataModel.clone()` method for properly cloning an instance of `DataModel` class.