### PR TITLE
implement closure parser

### DIFF
--- a/data-model.d.ts
+++ b/data-model.d.ts
@@ -43,9 +43,13 @@ export declare class DataModel extends SequentialEventEmitter{
     filter(params: any, callback?: (err?: Error, res?: any) => void): void;
     filterAsync(params: any): Promise<DataQueryable>;
     find(obj: any):DataQueryable;
+    select<T>(expr: (value: T, ...param: any) => any, ...params: any[]): DataQueryable;
+    select<T,J>(expr: (value1: T, value2: J, ...param: any) => any, ...params: any[]): DataQueryable;
     select(...attr: any[]): DataQueryable;
-    orderBy(attr: any): DataQueryable;
-    orderByDescending(attr: any): DataQueryable;
+    orderBy(attr: any): this;
+    orderBy<T>(expr: (value: T, ...params: any[]) => any): this;
+    orderByDescending(attr: any): this;
+    orderByDescending<T>(expr: (value: T) => any, ...params: any[]): this;
     take(n: number): DataQueryable;
     getList():Promise<any>;
     skip(n: number): DataQueryable;

--- a/data-queryable.d.ts
+++ b/data-queryable.d.ts
@@ -1,7 +1,7 @@
 // MOST Web Framework 2.0 Codename Blueshift BSD-3-Clause license Copyright (c) 2017-2022, THEMOST LP All rights reserved
 import {DataModel} from "./data-model";
 import {DataContextEmitter} from "./types";
-import {QueryExpression} from '@themost/query';
+import {QueryExpression, QueryFunc, QueryJoinFunc} from '@themost/query';
 
 export declare class DataQueryable implements DataContextEmitter {
     constructor(model: DataModel);
@@ -9,6 +9,7 @@ export declare class DataQueryable implements DataContextEmitter {
     readonly query: QueryExpression;
     clone(): this;
     where(attr: string): this;
+    where<T>(expr: QueryFunc<T>, ...params: unknown[]): this;
     search(text: string): this;
     join(model: string): this;
     and(attr: string): this;
@@ -29,12 +30,29 @@ export declare class DataQueryable implements DataContextEmitter {
     contains(value: any): this;
     notContains(value: any): this;
     between(value1: any, value2: any): this;
+    select<T>(expr: (value: T, ...param: any) => any, ...params: any[]): this;
+    select<T,J>(expr: (value1: T, value2: J, ...param: any) => any, ...params: any[]): this;
     select(...attr: any[]): this;
     orderBy(attr: any): this;
+    orderBy<T>(expr: (value: T, ...params: any[]) => any): this;
     orderByDescending(attr: any): this;
+    orderByDescending<T>(expr: (value: T) => any, ...params: any[]): this;
     thenBy(attr: any): this;
+    thenBy<T>(expr: (value: T) => any, ...params: any[]): this;
     thenByDescending(attr: any): this;
+    thenByDescending<T>(expr: (value: T) => any, ...params: any[]): this;
     groupBy(...attr: any[]): this;
+    groupBy<T>(...args: [...expr:[(value: T) => any], ...params: any[]]): this;
+    groupBy<T>(arg1: QueryFunc<T>, arg2: QueryFunc<T>, ...params: any[]): this;
+    groupBy<T>(arg1: QueryFunc<T>, arg2: QueryFunc<T>, arg3: QueryFunc<T>, ...params: any[]): this;
+    groupBy<T>(arg1: QueryFunc<T>, arg2: QueryFunc<T>, arg3: QueryFunc<T>,
+               arg4: QueryFunc<T>, ...params: any[]): this;
+    groupBy<T>(arg1: QueryFunc<T>, arg2: QueryFunc<T>, arg3: QueryFunc<T>,
+               arg4: QueryFunc<T>, arg5: QueryFunc<T>, ...params: any[]): this;
+    groupBy<T>(arg1: QueryFunc<T>, arg2: QueryFunc<T>, arg3: QueryFunc<T>,
+               arg4: QueryFunc<T>, arg5: QueryFunc<T>, arg6: QueryFunc<T>, ...params: any[]): this;
+    groupBy<T>(arg1: QueryFunc<T>, arg2: QueryFunc<T>, arg3: QueryFunc<T>,
+               arg4: QueryFunc<T>, arg5: QueryFunc<T>, arg6: QueryFunc<T> , arg7: QueryFunc<T>, ...params: any[]): this;
     skip(n:number): this;
     take(n:number): this;
     getItem(): Promise<any>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@themost/common": "^2.5.11",
         "@themost/json-logger": "^1.1.0",
         "@themost/peers": "^1.0.2",
-        "@themost/query": "^2.6.0",
+        "@themost/query": "^2.6.73",
         "@themost/sqlite": "^2.8.4",
         "@themost/xml": "^2.5.2",
         "@types/core-js": "^2.5.0",
@@ -5218,9 +5218,9 @@
       "integrity": "sha512-wlMYRsNWaz5EJ7AwCIA3yw2kHy4p36a4VTz8XmyYTYDYaKgmXjTi6IJPB/+di0mt/rf6NfFfsYwrmytoLseiIg=="
     },
     "node_modules/@themost/query": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.6.0.tgz",
-      "integrity": "sha512-kS+m0nSBKgz/sa5Fq2o4litgyTe5V8HImnmnJc+mFtqBWnteKd3+6xqtWJZv0TlTILz4t7pdq3JM21VBNBMXcA==",
+      "version": "2.6.73",
+      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.6.73.tgz",
+      "integrity": "sha512-Zl2FqaY6VQfmX7dX9xLcg0RV+TfifRG+onR8b1odTEyMZgKeiqCAUTakMbT7ADaBKYUe0Wat9iI4gZSFPHs7Og==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5228,7 +5228,6 @@
         "async": "^2.6.4",
         "esprima": "^4.0.1",
         "lodash": "^4.17.15",
-        "package-lock-only": "^0.0.4",
         "sprintf-js": "^1.1.2",
         "symbol": "^0.3.1"
       },
@@ -10976,17 +10975,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/package-lock-only": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/package-lock-only/-/package-lock-only-0.0.4.tgz",
-      "integrity": "sha512-fV1YHeTMWH5LKmdVqfWskm2/SG0iF2IrxJn3ziaPVx9CnpecGJzt8xXtLV+CYINENZwPFMtbxO5qupz0asNz1A==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "ISC",
-      "dependencies": {
-        "chalk": "^2.4.1"
-      }
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -16251,16 +16239,15 @@
       "integrity": "sha512-wlMYRsNWaz5EJ7AwCIA3yw2kHy4p36a4VTz8XmyYTYDYaKgmXjTi6IJPB/+di0mt/rf6NfFfsYwrmytoLseiIg=="
     },
     "@themost/query": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.6.0.tgz",
-      "integrity": "sha512-kS+m0nSBKgz/sa5Fq2o4litgyTe5V8HImnmnJc+mFtqBWnteKd3+6xqtWJZv0TlTILz4t7pdq3JM21VBNBMXcA==",
+      "version": "2.6.73",
+      "resolved": "https://registry.npmjs.org/@themost/query/-/query-2.6.73.tgz",
+      "integrity": "sha512-Zl2FqaY6VQfmX7dX9xLcg0RV+TfifRG+onR8b1odTEyMZgKeiqCAUTakMbT7ADaBKYUe0Wat9iI4gZSFPHs7Og==",
       "dev": true,
       "requires": {
         "@themost/events": "^1.0.5",
         "async": "^2.6.4",
         "esprima": "^4.0.1",
         "lodash": "^4.17.15",
-        "package-lock-only": "^0.0.4",
         "sprintf-js": "^1.1.2",
         "symbol": "^0.3.1"
       }
@@ -20614,15 +20601,6 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
-    },
-    "package-lock-only": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/package-lock-only/-/package-lock-only-0.0.4.tgz",
-      "integrity": "sha512-fV1YHeTMWH5LKmdVqfWskm2/SG0iF2IrxJn3ziaPVx9CnpecGJzt8xXtLV+CYINENZwPFMtbxO5qupz0asNz1A==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.4.1"
-      }
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "peerDependencies": {
     "@themost/common": "^2.5.11",
-    "@themost/query": "^2.6.0",
+    "@themost/query": "lts",
     "@themost/xml": "^2.5.2"
   },
   "engines": {
@@ -44,7 +44,7 @@
     "@themost/common": "^2.5.11",
     "@themost/json-logger": "^1.1.0",
     "@themost/peers": "^1.0.2",
-    "@themost/query": "^2.6.0",
+    "@themost/query": "^2.6.73",
     "@themost/sqlite": "^2.8.4",
     "@themost/xml": "^2.5.2",
     "@types/core-js": "^2.5.0",

--- a/spec/ClosureParser.spec.ts
+++ b/spec/ClosureParser.spec.ts
@@ -1,0 +1,239 @@
+import {TestUtils} from './adapter/TestUtils';
+import { TestApplication } from './TestApplication';
+import { DataContext } from '../types';
+import { DataConfigurationStrategy } from '../data-configuration';
+import { round, count } from '@themost/query';
+import { resolve } from 'path';
+const { executeInTransaction } = TestUtils;
+
+describe('ClosureParser', () => {
+
+    let app: TestApplication;
+    let context: DataContext;
+
+    beforeAll(async () => {
+        app = new TestApplication(resolve(__dirname, 'test2'));
+        context = app.createContext();
+    });
+
+    afterAll(async () => {
+        await context.finalizeAsync();
+        await app.finalize();
+    });
+
+    it('should use select closure', async () => {
+        await executeInTransaction(context, async () => {
+            const items = await context.model('Product').select((x: any) => {
+                return {
+                    id: x.id,
+                    name: x.name,
+                    category: x.category,
+                    newPrice: round(x.price, 2)
+                }
+            }).silent().take(10).getItems();
+            expect(Array.isArray(items)).toBeTruthy();
+            expect(items.length).toBeTruthy();
+        });
+    });
+
+    it('should use select closure with params', async () => {
+        await executeInTransaction(context, async () => {
+            const items = await context.model('Product').asQueryable().select((x: any, digits: number) => {
+                return {
+                    id: x.id,
+                    name: x.name,
+                    category: x.category,
+                    newPrice: round(x.price, digits)
+                }
+            }, 2).silent().take(10).getItems();
+            expect(Array.isArray(items)).toBeTruthy();
+            expect(items.length).toBeTruthy();
+        });
+    });
+
+    it('should use select closure with nested attributes', async () => {
+        await executeInTransaction(context, async () => {
+            const items = await context.model('Order').select((x: any) => {
+                return {
+                    id: x.id,
+                    customer: x.customer.givenName.concat(' ', x.customer.familyName),
+                    streetAddress: x.customer.address.streetAddress,
+                    orderedItem: x.orderedItem.name,
+                    orderStatus: x.orderStatus.name,
+                    orderDate: x.orderDate
+                }
+            }).silent().take(10).getItems();
+            expect(Array.isArray(items)).toBeTruthy();
+            expect(items.length).toBeTruthy();
+            for (const item of items) {
+                expect(Object.prototype.hasOwnProperty.call(item, 'streetAddress')).toBeTruthy();
+                expect(typeof item.streetAddress === 'string').toBeTruthy();
+                expect(Object.prototype.hasOwnProperty.call(item, 'customer')).toBeTruthy();
+                expect(typeof item.customer === 'string').toBeTruthy();
+            }
+        });
+    });
+
+    it('should use select closure with functions', async () => {
+        await executeInTransaction(context, async () => {
+            const items = await context.model('Order').select((x: any) => {
+                return {
+                    id: x.id,
+                    customer: x.customer.givenName.concat(' ', x.customer.familyName),
+                    streetAddress: x.customer.address.streetAddress,
+                    orderedItem: x.orderedItem.name,
+                    releaseYear: x.orderedItem.releaseDate.getFullYear(),
+                    orderStatus: x.orderStatus.name,
+                    orderYear: x.orderDate.getFullYear()
+                }
+            }).silent().take(10).getItems();
+            expect(Array.isArray(items)).toBeTruthy();
+            expect(items.length).toBeTruthy();
+            for (const item of items) {
+                expect(Object.prototype.hasOwnProperty.call(item, 'orderYear')).toBeTruthy();
+                expect(typeof item.orderYear === 'number').toBeTruthy();
+                expect(Object.prototype.hasOwnProperty.call(item, 'releaseYear')).toBeTruthy();
+                expect(typeof item.releaseYear === 'number').toBeTruthy();
+            }
+        });
+    });
+
+    it('should use select closure with nested attribute', async () => {
+        await executeInTransaction(context, async () => {
+            const items = await context.model('Order').select((x: any) => {
+                return {
+                    id: x.id,
+                    orderDate: x.orderDate,
+                    productName: x.orderedItem.name,
+                    productPrice: x.orderedItem.price
+                }
+            }).silent().take(10).getItems();
+            expect(Array.isArray(items)).toBeTruthy();
+            expect(items.length).toBeTruthy();
+        });
+    });
+
+    it('should use expand', async () => {
+        await executeInTransaction(context, async () => {
+            const items = await context.model('Order').select((x: any) => {
+                return {
+                    id: x.id,
+                    orderedItem: x.orderedItem,
+                    orderDate: x.orderDate,
+                    productName: x.orderedItem.name,
+                    productPrice: x.orderedItem.price
+                }
+            }).expand((x: any) => x.orderedItem).silent().take(10).getItems();
+            expect(Array.isArray(items)).toBeTruthy();
+            expect(items.length).toBeTruthy();
+            for (const item of items) {
+                expect(item.orderedItem).toBeTruthy();
+            }
+        });
+    });
+
+    it('should use nested expand', async () => {
+        await executeInTransaction(context, async () => {
+            const items = await context.model('Order').select((x: any) => {
+                return {
+                    id: x.id,
+                    customer: x.customer,
+                    country: x.customer.address.addressCountry,
+                    orderDate: x.orderDate,
+                    productName: x.orderedItem.name,
+                    productPrice: x.orderedItem.price
+                }
+            }).expand((x: any) => x.customer.address).silent().take(10).getItems();
+            expect(Array.isArray(items)).toBeTruthy();
+            expect(items.length).toBeTruthy();
+            for (const item of items) {
+                expect(item.customer).toBeTruthy();
+                expect(item.customer.address).toBeTruthy();
+            }
+        });
+    });
+
+    it('should use where closure', async () => {
+        await executeInTransaction(context, async () => {
+            const Products = context.model('Product');
+        const results = await Products.select((x: any) => {
+                x.id,
+                x.name,
+                x.category,
+                x.model,
+                x.price
+            }).where((x: any) => {
+                return x.price > 400;
+            }).take(10).silent().getItems();
+            results.forEach((item) => {
+                expect(item.price).toBeGreaterThan(400);
+            });
+        });
+    });
+
+    it('should use order by closure', async () => {
+        await executeInTransaction(context, async () => {
+            const Products = context.model('Product');
+            const results = await Products.select((x: any) => {
+                x.id,
+                x.name,
+                x.category,
+                x.model,
+                x.price
+            }).where((x: any) => {
+                return x.price > 400;
+            }).orderBy(
+                (x: any) => x.price
+            ).take(10).silent().getItems();
+            results.forEach( (x, index) => {
+                if (index > 0) {
+                    expect(x.price).toBeGreaterThanOrEqual(results[index-1].price);
+                }
+            });
+        });
+    });
+
+    it('should use group by closure', async () => {
+        await executeInTransaction(context, async () => {
+            const category = 'Laptops';
+            const items = await context.model('Order')
+            .select((x: any) => {
+                return {
+                    total: count(x.id),
+                    product: x.orderedItem.name,
+                    model:  x.orderedItem.model
+                }
+            })
+            .groupBy((x: any) => x.orderedItem.name, (x: { orderedItem: { model: any; }; }) => x.orderedItem.model)
+            .where((x: any, category: string) => {
+                return  x.orderedItem.category === category;
+            }, {
+                category
+            }).silent().take(10).getItems();
+            expect(Array.isArray(items)).toBeTruthy();
+            expect(items.length).toBeTruthy();
+        });
+    });
+
+    it('should use group by closure with nested attributes', async () => {
+        await executeInTransaction(context, async () => {
+            const orderStatus = 'OrderDelivered';
+            const items = await context.model('Order')
+            .select((x: any) => {
+                return {
+                    total: count(x.id),
+                    country: x.customer.address.addressCountry.name
+                }
+            })
+            .where<any>((x: any, orderStatus: string) => {
+                return x.orderStatus.alternateName === orderStatus;
+            }, {
+                orderStatus
+            })
+            .groupBy<any>((x) => x.customer.address.addressCountry).silent().take(10).getItems();
+            expect(Array.isArray(items)).toBeTruthy();
+            expect(items.length).toBeTruthy();
+        });
+    });
+
+});

--- a/spec/DataQueryable.select.spec.ts
+++ b/spec/DataQueryable.select.spec.ts
@@ -1,0 +1,100 @@
+import { resolve } from 'path';
+import { DataContext } from '../index';
+import { TestApplication } from './TestApplication';
+import { TestUtils } from './adapter/TestUtils';
+import { round } from '@themost/query';
+import { executeInUnattendedModeAsync } from '../UnattendedMode';
+const {executeInTransaction} = TestUtils;
+
+describe('DataQueryable.select()', () => {
+    let app: TestApplication;
+    let context: DataContext;
+    beforeAll(async () => {
+        app = new TestApplication(resolve(__dirname, 'test2'));
+        context = app.createContext();
+    });
+    afterAll(async () => {
+        await app.finalize();
+    })
+    it('should use a simple select closure', async () => {
+        const items = await context.model('Product').asQueryable()
+        .select<{ id?: number, name: string, price?: number }>(({id, name, price}) => ({
+            id,
+            name,
+            price
+        })).take(10).getItems();
+        expect(items.length).toBeGreaterThan(0);
+        const [item] = items;
+        expect(Object.getOwnPropertyNames(item)).toStrictEqual(['id', 'name', 'price']);
+    });
+
+    it('should use round', async () => {
+        const items = await context.model('Product').asQueryable()
+        .select<{ id?: number, name: string, price?: number }>(({id, name, price}) => {
+            return {
+                id,
+                name,
+                price,
+                actualPrice: round(price, 2)
+            }            
+        }).take(10).getItems();
+        expect(items.length).toBeGreaterThan(0);
+        for (const item of items) {
+            expect(item.actualPrice).toBeCloseTo(item.price, 2);
+        }
+    });
+
+    it('should use where closure', async () => {
+        const items = await context.model('Product').asQueryable()
+        .select<any>(({id, name, price, category}) => {
+            return {
+                id,
+                name,
+                price,
+                category
+            }            
+        }).where((x: any) => {
+            return x.category === 'Laptops' && x.price > 500;
+        }).take(10).getItems();
+        expect(items.length).toBeGreaterThan(0);
+        for (const item of items) {
+            expect(item.category).toEqual('Laptops');
+            expect(item.price).toBeGreaterThan(500);
+        }
+    });
+
+    it('should use where closure with params', async () => {
+        const targetCategory = 'Laptops';
+        const items = await context.model('Product').asQueryable()
+        .select<any>(({id, name, price, category}) => {
+            return {
+                id,
+                name,
+                price,
+                category
+            }            
+        }).where((x: any, category: string) => {
+            return x.category === category;
+        }, targetCategory).take(10).getItems();
+        expect(items.length).toBeGreaterThan(0);
+        for (const item of items) {
+            expect(item.category).toEqual('Laptops');
+        }
+    });
+
+    it('should use where with nested query', async () => {
+        await executeInUnattendedModeAsync(context, async () => {
+            const targetCategory = 'Laptops';
+            const items = await context.model('Order').asQueryable()
+            .where((x: any, category: string) => {
+                return x.orderedItem.category === category;
+            }, targetCategory).take(25).getItems();
+            expect(items.length).toBeGreaterThan(0);
+            for (const item of items) {
+                expect(item.orderedItem.category).toEqual('Laptops');
+            }
+        });
+    });
+    
+    
+});


### PR DESCRIPTION
This PR implements closure parser as extension of `@themost/query` specification about using native closures for creating queries e.g.
```typescript
const items = await context.model('Product').asQueryable()
        .select<{ id?: number, name: string, price?: number }>(({id, name, price}) => ({
            id,
            name,
            price
})).take(10).getItems();
```