### PR TITLE
use uknown json attribute

### DIFF
--- a/data-model.js
+++ b/data-model.js
@@ -23,7 +23,7 @@ var DataObjectAssociationListener = dataAssociations.DataObjectAssociationListen
 var {DataModelView} = require('./data-model-view');
 var {DataFilterResolver} = require('./data-filter-resolver');
 var Q = require('q');
-var {SequentialEventEmitter} = require('@themost/common');
+var {SequentialEventEmitter, Args} = require('@themost/common');
 var {LangUtils} = require('@themost/common');
 var {TraceUtils} = require('@themost/common');
 var {DataError} = require('@themost/common');
@@ -46,6 +46,7 @@ var { OnJsonAttribute } = require('./OnJsonAttribute');
 var { isObjectDeep } = require('./is-object');
 var { DataStateValidatorListener } = require('./data-state-validator');
 var resolver = require('./data-expand-resolver');
+var { isArrayLikeObject } = require('lodash/isArrayLikeObject');
 /**
  * @this DataModel
  * @param {DataField} field
@@ -1507,7 +1508,14 @@ function cast_(obj, state) {
                 if (mapping == null) {
                     var {[name]: value} = obj;
                     if (x.type === 'Json') {
-                        result[x.name] = isObjectDeep(value) ? JSON.stringify(value) : null;
+                        // check if value is an object or an array
+                        if (value == null) {
+                            result[x.name] = null;
+                        } else {
+                            var isObjectOrArray = isObjectDeep(value) || isArrayLikeObject(value);
+                            Args.check(isObjectOrArray, new DataError('ERR_VALUE','Invalid attribute value. Expected a valid object or an array.', null, self.name, x.name));
+                            result[x.name] = JSON.stringify(value);
+                        }
                     } else {
                         result[x.name] = value;
                     }

--- a/spec/JsonAttribute.spec.ts
+++ b/spec/JsonAttribute.spec.ts
@@ -49,6 +49,27 @@ describe('JsonAttribute', () => {
         });
     });
 
+    it('should update unknown json attribute', async () => {
+        await TestUtils.executeInTransaction(context, async () => {
+            const Products = context.model('Product').silent();
+            let item = await Products.where('name').equal('Apple MacBook Air (13.3-inch, 2013 Version)').getItem()
+            expect(item).toBeTruthy();
+            item.extraAttributes = {
+                cpu: 'Intel Core i5',
+                ram: '8GB'
+            }
+            await Products.save(item);
+            expect(item.dateCreated).toBeTruthy();
+            item = await Products.where('name').equal('Apple MacBook Air (13.3-inch, 2013 Version)')
+                .select('extraAttributes/cpu as cpu').getItem();
+            expect(item).toBeTruthy();
+            expect(item.cpu).toBe('Intel Core i5');
+            item = await Products.where('name').equal('Apple MacBook Air (13.3-inch, 2013 Version)').getItem();
+            expect(item).toBeTruthy();
+            expect(item.extraAttributes).toBeTruthy();
+        });
+    });
+
     it('should update json structured value', async () => {
         await TestUtils.executeInTransaction(context, async () => {
             const Products = context.model('Product').silent();

--- a/spec/test2/config/models/Product.json
+++ b/spec/test2/config/models/Product.json
@@ -5,7 +5,7 @@
   "hidden": false,
   "sealed": false,
   "abstract": false,
-  "version": "2.2.1",
+  "version": "2.2.2",
   "inherits": "Thing",
   "caching": "conditional",
   "fields": [
@@ -232,6 +232,11 @@
       "type": "Json",
       "indexed": true,
       "additionalType": "ProductMetadata"
+    },
+    {
+      "name": "extraAttributes",
+      "many": false,
+      "type": "Json"
     }
   ],
   "constraints": [


### PR DESCRIPTION
This PR updates JSON attributes implementation for accepting data without validating them against a known object type e.g. `Product` model has a field `extraAttributes` where `additionalType` is missing which indicates that this field can accept any JSON value instead of validating it against a known object schema.
```json
{
   "name": "extraAttributes",
    "many": false,
    "type": "Json"
}
```

where an update operation will omit validation of `extraAttributes` value.

```javascript
const item = await Products.where('name').equal('Apple MacBook Air (13.3-inch, 2013 Version)').getItem()
item.extraAttributes = {
    cpu: 'Intel Core i5',
    ram: '8GB'
}
await Products.save(item);
```


