### PR TITLE
downgrade node-cache back to 1.1.0

### DIFF
--- a/data-cache.js
+++ b/data-cache.js
@@ -127,7 +127,10 @@ class DefaultDataCacheStrategy extends DataCacheStrategy {
                     if (err) {
                         return reject(err);
                     }
-                    return resolve(res);
+                    if (Object.prototype.hasOwnProperty.call(res, key)) {
+                        return resolve(res[key]);
+                    }
+                    return resolve();
                 });
             } catch (err) {
                 return reject(err);
@@ -180,9 +183,9 @@ class DefaultDataCacheStrategy extends DataCacheStrategy {
     finalize() {
         var self = this;
         return self.clear().then(function() {
-            // destroy timer
-            if (self.rawCache) {
-                self.rawCache.close();
+            if (self.rawCache.checkTimeout != null) {
+                clearTimeout(self.rawCache.checkTimeout);
+                return Promise.resolve();
             }
         });
     }
@@ -201,7 +204,9 @@ class DefaultDataCacheStrategy extends DataCacheStrategy {
             try {
                 void self.rawCache.get(key, (err, res) => {
                     if (typeof res !== 'undefined') {
-                        return resolve(res);
+                        if (Object.prototype.hasOwnProperty.call(res, key)) {
+                            return resolve(res[key]);
+                        }
                     }
                     try {
                         void getFunc().then(function (res) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "esprima": "^4.0.1",
         "lodash": "^4.17.21",
         "moment": "^2.30.1",
-        "node-cache": "^4.2.1",
+        "node-cache": "^1.1.0",
         "pluralize": "^7.0.0",
         "q": "^1.4.1",
         "sprintf-js": "^1.1.2",
@@ -6218,15 +6218,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -10763,13 +10754,11 @@
       }
     },
     "node_modules/node-cache": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
-      "integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
-      "license": "MIT",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-1.1.0.tgz",
+      "integrity": "sha512-3q6GeGOZuI+yeZzM8IV9pjzEXg5v8/w6WfW2uIunDnacv9mDNBlVcUdbJGL2sr8aG7dP7Cw1KApnEDAk9poR8g==",
       "dependencies": {
-        "clone": "2.x",
-        "lodash": "^4.17.15"
+        "underscore": "*"
       },
       "engines": {
         "node": ">= 0.4.6"
@@ -12058,6 +12047,12 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -17039,11 +17034,6 @@
         "wrap-ansi": "^7.0.0"
       }
     },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
-    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -20472,12 +20462,11 @@
       "dev": true
     },
     "node-cache": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
-      "integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-1.1.0.tgz",
+      "integrity": "sha512-3q6GeGOZuI+yeZzM8IV9pjzEXg5v8/w6WfW2uIunDnacv9mDNBlVcUdbJGL2sr8aG7dP7Cw1KApnEDAk9poR8g==",
       "requires": {
-        "clone": "2.x",
-        "lodash": "^4.17.15"
+        "underscore": "*"
       }
     },
     "node-gyp": {
@@ -21412,6 +21401,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
       "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
+    },
+    "underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.6.76",
+  "version": "2.6.77",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.6.76",
+      "version": "2.6.77",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "esprima": "^4.0.1",
     "lodash": "^4.17.21",
     "moment": "^2.30.1",
-    "node-cache": "^4.2.1",
+    "node-cache": "^1.1.0",
     "pluralize": "^7.0.0",
     "q": "^1.4.1",
     "sprintf-js": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.76",
+  "version": "2.6.77",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This PR downgrades node-cache to version 1.1.0 for resolving performance issues