### PR TITLE
get values when passing objects

### DIFF
--- a/data-mapping-extensions.js
+++ b/data-mapping-extensions.js
@@ -5,6 +5,7 @@ var {QueryEntity} = require('@themost/query');
 var {QueryField} = require('@themost/query');
 var Q = require('q');
 var {hasOwnProperty} = require('./has-own-property');
+var {isObjectDeep} = require('./is-object');
 
 class DataMappingExtender {
     constructor(mapping) {
@@ -342,9 +343,20 @@ class DataMappingExtender {
                 if (_.isNil(childField)) {
                     return reject('The specified field cannot be found on child model');
                 }
+                var childFieldType = thisQueryable.model.context.model(childField.type);
                 var values = _.intersection(_.map(_.filter(arr, function(x) {
                     return hasOwnProperty(x, keyField);
-                    }), function (x) { return x[keyField];}));
+                }), function (x) { return x[keyField];})).map(function(x) {
+                    if (isObjectDeep(x)) {
+                        if (childFieldType) {
+                            return x[childFieldType.primaryKey];
+                        } 
+                        throw new Error('The child item is an object but its type cannot determined.');
+                    }
+                    return x;
+                }).filter(function(x) {
+                    return x != null;
+                });
                 if (values.length===0) {
                     return resolve();
                 }
@@ -421,9 +433,20 @@ class DataMappingExtender {
                     return reject('The specified field cannot be found on parent model');
                 }
                 var keyField = parentField.property || parentField.name;
+                var parentFieldType = thisQueryable.model.context.model(parentField.type);
                 var values = _.intersection(_.map(_.filter(arr, function(x) {
                     return hasOwnProperty(x, keyField);
-                }), function (x) { return x[keyField];}));
+                }), function (x) { return x[keyField];})).map(function(x) {
+                    if (isObjectDeep(x)) {
+                        if (parentFieldType) {
+                            return x[parentFieldType.primaryKey];
+                        } 
+                        throw new Error('The parent item is an object but its type cannot determined.');
+                    }
+                    return x;
+                }).filter(function(x) {
+                    return x != null;
+                });
                 if (values.length===0) {
                     return resolve();
                 }
@@ -528,7 +551,7 @@ class DataMappingExtender {
                         });
                         return resolve();
                     }).catch(function(err) {
-                        return resolve(err);
+                        return reject(err);
                     });
                 });
             });
@@ -872,11 +895,22 @@ class DataMappingOptimizedExtender extends DataMappingExtender {
                     return reject('The specified field cannot be found on parent model');
                 }
                 var keyField = parentField.property || parentField.name;
+                var parentFieldType = thisQueryable.model.context.model(parentField.type);
                 var values = _.intersection(_.map(_.filter(arr, function(x) {
                     return hasOwnProperty(x, keyField);
                 }), function (x) {
                     return x[keyField];
-                }));
+                })).map(function(x) {
+                    if (isObjectDeep(x)) {
+                        if (parentFieldType) {
+                            return x[parentFieldType.primaryKey];
+                        } 
+                        throw new Error('The parent item is an object but its type cannot determined.');
+                    }
+                    return x;
+                }).filter(function(x) {
+                    return x != null;
+                });;
                 if (values.length===0) {
                     return resolve();
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.6.78",
+  "version": "2.6.79",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.6.78",
+      "version": "2.6.79",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.78",
+  "version": "2.6.79",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This PR updates `DataMappingExtender` to validate the given values that are going to be passed for getting associated objects and flatten them if they objects e.g. `{  "id": 450, "name": "A product"  }` instead of `450`.