### PR TITLE
Fix data mapping extender errors

### DIFF
--- a/data-mapping-extensions.js
+++ b/data-mapping-extensions.js
@@ -6,6 +6,7 @@ var {QueryField} = require('@themost/query');
 var Q = require('q');
 var {hasOwnProperty} = require('./has-own-property');
 var {isObjectDeep} = require('./is-object');
+var {DataError} = require('@themost/common')
 
 class DataMappingExtender {
     constructor(mapping) {
@@ -60,7 +61,7 @@ class DataMappingExtender {
                 return resolve();
             }
             if (_.isNil(thisQueryable)) {
-                return reject('The underlying data queryable cannot be empty at this context.');
+                return reject(new Error('The underlying data queryable cannot be empty at this context.'));
             }
             if ((mapping.childModel !== thisQueryable.model.name) || (mapping.associationType!=='junction')) {
                 return resolve();
@@ -341,7 +342,7 @@ class DataMappingExtender {
                 var childField = thisQueryable.model.field(mapping.childField);
                 var keyField = childField.property || childField.name;
                 if (_.isNil(childField)) {
-                    return reject('The specified field cannot be found on child model');
+                    return reject(new DataError('E_ATTR', `The specified field "${mapping.childField}" cannot be found in child model "${mapping.childModel}"`, null, mapping.childModel, mapping.childField));
                 }
                 var childFieldType = thisQueryable.model.context.model(childField.type);
                 var values = _.intersection(_.map(_.filter(arr, function(x) {
@@ -430,7 +431,7 @@ class DataMappingExtender {
                 if (err) { return reject(err); }
                 var parentField = thisQueryable.model.field(mapping.parentField);
                 if (_.isNil(parentField)) {
-                    return reject('The specified field cannot be found on parent model');
+                    return reject(new DataError('E_ATTR', `The specified field "${mapping.parentField}" cannot be found in parent model "${mapping.parentModel}"`, null, mapping.parentModel, mapping.parentField));
                 }
                 var keyField = parentField.property || parentField.name;
                 var parentFieldType = thisQueryable.model.context.model(parentField.type);
@@ -450,14 +451,15 @@ class DataMappingExtender {
                 if (values.length===0) {
                     return resolve();
                 }
+                const childModel = thisArg.getChildModel();
                 //search for view named summary
-                thisArg.getChildModel().filter(mapping.options, function(err, q) {
+                childModel.filter(mapping.options, function(err, q) {
                     if (err) {
                         return reject(err);
                     }
-                    var childField = thisArg.getChildModel().field(mapping.childField);
+                    var childField = childModel.field(mapping.childField);
                     if (_.isNil(childField)) {
-                        return reject('The specified field cannot be found on child model');
+                        return reject(new DataError('E_ATTR', `The specified field "${mapping.childField}" cannot be found in child model "${mapping.childModel}"`, null, mapping.childModel, mapping.childField));
                     }
                     var foreignKeyField = childField.property || childField.name;
                     //Important Backward compatibility issue (<1.8.0)
@@ -892,7 +894,7 @@ class DataMappingOptimizedExtender extends DataMappingExtender {
                 }
                 var parentField = thisArg.getParentModel().field(mapping.parentField);
                 if (parentField == null) {
-                    return reject('The specified field cannot be found on parent model');
+                    return reject(new DataError('E_ATTR', `The specified field "${mapping.parentField}" cannot be found in parent model "${mapping.parentModel}"`, null, mapping.parentModel, mapping.parentField));
                 }
                 var keyField = parentField.property || parentField.name;
                 var parentFieldType = thisQueryable.model.context.model(parentField.type);
@@ -921,7 +923,7 @@ class DataMappingOptimizedExtender extends DataMappingExtender {
                     }
                     var childField = thisArg.getChildModel().field(mapping.childField);
                     if (childField == null) {
-                        return reject('The specified field cannot be found on child model');
+                        return reject(new DataError('E_ATTR', `The specified field "${mapping.childField}" cannot be found in child model "${mapping.childModel}"`, null, mapping.childModel, mapping.childField));
                     }
                     var foreignKeyField = childField.property || childField.name;
                     //Important Backward compatibility issue (<1.8.0)

--- a/data-queryable.js
+++ b/data-queryable.js
@@ -2841,7 +2841,8 @@ function afterExecute_(result, callback) {
                 }
             }
             else {
-                return cb(new DataError('EASSOC', sprintf('Data association mapping (%s) for %s cannot be found or the association between these two models defined more than once.', expand, self.model.title)));
+                const expandName = typeof expand === 'string' ? expand : expand && expand.name;
+                return cb(new DataError('EASSOC', sprintf('Data association mapping (%s) for %s cannot be found or the association between these two models defined more than once.', expandName, self.model.name)));
             }
         }, function(err) {
             if (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.6.79",
+  "version": "2.6.80",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.6.79",
+      "version": "2.6.80",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.79",
+  "version": "2.6.80",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This PR fixes and upgrades errors thrown by `DataMappingExtender` class when an association between two models is of a wrong type.