### PR TITLE
set object type for data object tags

### DIFF
--- a/data-object-tag.js
+++ b/data-object-tag.js
@@ -99,6 +99,7 @@ function DataObjectTag(obj, association) {
                             'name': associationObjectField,
                             'type': objectFieldType,
                             'nullable': false,
+                            'editable': false,
                             'many': false,
                             'indexed': true
                         },

--- a/data-object-tag.js
+++ b/data-object-tag.js
@@ -81,8 +81,7 @@ function DataObjectTag(obj, association) {
                 // get value type
                 var refersTo = context.model(self.mapping.parentModel).getAttribute(self.mapping.refersTo);
                 var refersToType = (refersTo && refersTo.type) || 'Text';
-                var objectFieldType = parentModel.getAttribute(self.mapping.parentField).type;
-                if (objectFieldType === 'Counter') { objectFieldType = 'Integer'; }
+                var objectFieldType = self.mapping.parentModel;
                 definition = {
                     'name': self.mapping.associationAdapter,
                     'hidden': true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.18.3",
+      "version": "2.18.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR changes the definition of data models automatically generated for `DataObjectTag` relationships to use the type of the parent object instead of the type of the primary key of the parent object. Data object tags define an association between a model and a collection of primitive typed values like Text, Number etc.