### PR TITLE
Force set distinct values

### DIFF
--- a/data-attribute-resolver.d.ts
+++ b/data-attribute-resolver.d.ts
@@ -5,9 +5,9 @@ export declare class DataAttributeResolver {
     selectNestedAttribute(attr: string): any;
     selectAggregatedAttribute(aggregation: string, attribute: string, alias: string): any;
     resolveNestedAttribute(attr: string): any;
-    resolveNestedAttributeJoin(memberExpr: string): { $select?: QueryField | MethodCallExpression, $expand?: QueryEntity[] };
+    resolveNestedAttributeJoin(memberExpr: string): { $select?: QueryField | MethodCallExpression, $expand?: QueryEntity[], $distinct?: boolean };
     testAttribute(s: string): any;
     testAggregatedNestedAttribute(s: string): any;
     testNestedAttribute(s: string): any;
-    resolveJunctionAttributeJoin(attr: string): { $select?: QueryField | MethodCallExpression, $expand?: QueryEntity[] };
+    resolveJunctionAttributeJoin(attr: string): { $select?: QueryField | MethodCallExpression, $expand?: QueryEntity[], $distinct?: boolean };
 }

--- a/data-attribute-resolver.js
+++ b/data-attribute-resolver.js
@@ -1,4 +1,4 @@
-var {QueryField, QueryEntity, QueryUtils, MethodCallExpression, MemberExpression, Expression} = require('@themost/query');
+var {QueryField, QueryEntity, QueryUtils, MethodCallExpression, MemberExpression} = require('@themost/query');
 var {sprintf} = require('sprintf-js');
 var _ = require('lodash');
 var {DataError} = require('@themost/common');
@@ -166,7 +166,7 @@ DataAttributeResolver.prototype.resolveNestedAttribute = function(attr) {
 /**
  *
  * @param {*} memberExpr - A string that represents a member expression e.g. user/id or article/published etc.
- * @returns {{$select?:QueryField,$expand?:{QueryEntity}[]}} - An object that represents a query join expression
+ * @returns {{$select?:QueryField,$expand?:{QueryEntity}[],$distinct?:boolean}} - An object that represents a query join expression
  */
 DataAttributeResolver.prototype.resolveNestedAttributeJoin = function(memberExpr) {
     var self = this, childField, parentField, res, expr, entity;
@@ -221,7 +221,7 @@ DataAttributeResolver.prototype.resolveNestedAttributeJoin = function(memberExpr
             var childFieldName = childField.property || childField.name;
             /**
              * store temp query expression
-             * @type QueryExpression
+             * @type {import('@themost/query').QueryExpression}
              */
             res =QueryUtils.query(self.viewAdapter).select(['*']);
             expr = QueryUtils.query().where(QueryField.select(childField.name)
@@ -239,6 +239,7 @@ DataAttributeResolver.prototype.resolveNestedAttributeJoin = function(memberExpr
                 parentModel[aliasProperty] = mapping.childField;
                 expr = new DataAttributeResolver().resolveNestedAttributeJoin.call(parentModel, arrMember.slice(1).join('/'));
                 return {
+                    $distinct: expr.$distinct,
                     $select: expr.$select,
                     $expand: [].concat(res.$expand).concat(expr.$expand)
                 };
@@ -528,10 +529,11 @@ DataAttributeResolver.prototype.testNestedAttribute = function(s) {
 
 /**
  * @param {string} attr
- * @returns {{$select?:QueryField,$expand?:{QueryEntity}[]}}
+ * @returns {{$select?:QueryField,$expand?:{QueryEntity}[],$distinct?:boolean}}
  */
 DataAttributeResolver.prototype.resolveJunctionAttributeJoin = function(attr) {
     var self = this, member = attr.split('/');
+    var $distinct = false;
     //get the data association mapping
     var mapping = self.inferMapping(member[0]);
     //if mapping defines a junction between two models
@@ -548,6 +550,8 @@ DataAttributeResolver.prototype.resolveJunctionAttributeJoin = function(attr) {
             entity = new QueryEntity(mapping.associationAdapter).as(associationAlias);
             if (field.multiplicity === 'ZeroOrOne') {
                 entity.$join = 'left';
+            } else {
+                $distinct = true;
             }
             Object.defineProperty(entity, 'model', {
                 configurable: true,
@@ -564,12 +568,13 @@ DataAttributeResolver.prototype.resolveJunctionAttributeJoin = function(attr) {
             //data object tagging
             if (typeof mapping.childModel === 'undefined') {
                 return {
+                    $distinct,
                     $expand:[q.$expand],
                     $select:QueryField.select(mapping.associationValueField).from(associationAlias)
                 }
             }
 
-            //return the resolved attribute for futher processing e.g. members.id
+            //return the resolved attribute for further processing e.g. members.id
             // if (member[1] === mapping.childField) {
             //     return {
             //         $expand:[q.$expand],
@@ -585,8 +590,12 @@ DataAttributeResolver.prototype.resolveJunctionAttributeJoin = function(attr) {
                 //create new join
                 var alias = field.name; // + '_' + childModel.name;
                 entity = new QueryEntity(childModel.viewAdapter).as(alias);
+
                 if (field.multiplicity === 'ZeroOrOne') {
                     entity.$join = 'left';
+                } else {
+                    // issue #226: enable getting distinct values
+                    $distinct = true;
                 }
                 // set model
                 Object.defineProperty(entity, 'model', {
@@ -600,6 +609,7 @@ DataAttributeResolver.prototype.resolveJunctionAttributeJoin = function(attr) {
                 //append join
                 q.join(entity).with(expr);
                 return {
+                    $distinct,
                     $expand:q.$expand,
                     $select:QueryField.select(member[1] || mapping.childField).from(alias)
                 }
@@ -643,6 +653,7 @@ DataAttributeResolver.prototype.resolveJunctionAttributeJoin = function(attr) {
                 //append join
                 q.join(entity).with(expr);
                 return {
+                    $distinct: true,
                     $expand:q.$expand,
                     $select:QueryField.select(member[1]).from(parentAlias)
                 }
@@ -668,7 +679,7 @@ DataAttributeResolver.prototype.resolveZeroOrOneNestedAttribute = function(attr)
     while (index < fullyQualifiedMember.length) {
         var member = fullyQualifiedMember[index];
         var attribute = currentModel.getAttribute(member);
-        if (attribute.multiplicity != 'ZeroOrOne') {
+        if (attribute.multiplicity !== 'ZeroOrOne') {
             // do nothing
         }
     }

--- a/data-model.js
+++ b/data-model.js
@@ -735,6 +735,8 @@ function filterInternal(params, callback) {
     var self = this;
     var parser = OpenDataParser.create()
     var $joinExpressions = [];
+    // issue #226: enable getting distinct values
+    var $distinct = false;
     var view;
     var selectAs = [];
     parser.resolveMember = function(member, cb) {
@@ -777,11 +779,17 @@ function filterInternal(params, callback) {
                     expr = {
                         $expand: expr1.$expand
                     };
+                    if (expr1.$distinct) {
+                        $distinct = true;
+                    }
                     //replace member expression
                     member = expr1.$select.$name.replace(/\./g,'/');
                 }
                 else {
                     expr = DataAttributeResolver.prototype.resolveNestedAttributeJoin.call(self, member);
+                    if (expr.$distinct) {
+                        $distinct = true;
+                    }
                     // get member expression
                     if (expr && expr.$select && Object.prototype.hasOwnProperty.call(expr.$select, '$value')) {
                         // get value
@@ -974,6 +982,11 @@ function filterInternal(params, callback) {
                     }
                     if (query.$group) {
                         q.query.$group = query.$group;
+                    } else {
+                        // issue #226: enable getting distinct values
+                        if ($distinct) {
+                            q.distinct();
+                        }
                     }
                     // assign join expressions
                     if ($joinExpressions.length>0) {

--- a/spec/DistinctValues.spec.ts
+++ b/spec/DistinctValues.spec.ts
@@ -1,0 +1,102 @@
+import {TestUtils} from './adapter/TestUtils';
+import {TestApplication, TestApplication2} from './TestApplication';
+import {DataContext} from '../types';
+
+describe('Distinct Values', () => {
+    let app: TestApplication;
+    let context: DataContext;
+    beforeAll(async () => {
+        app = new TestApplication2();
+        context = app.createContext();
+    });
+    afterAll(async () => {
+        await context.finalizeAsync();
+        await app.finalize();
+    });
+
+    it('should force distinct items using $filter', async () => {
+        Object.assign(context, {
+            user: {
+                name: 'alexis.rees@example.com'
+            }
+        });
+        await TestUtils.executeInTransaction(context, async () => {
+            let user = await context.model('User').where('name').equal('luis.nash@example.com').getTypedItem();
+
+            await context.model('Group').insert({
+                name: 'SpecialAgents'
+            })
+
+            await user.property('groups').insert({
+                name: 'SpecialAgents'
+            });
+            user = await context.model('User').where('name').equal('alexis.rees@example.com').getTypedItem();
+            await user.property('groups').insert([
+                {
+                    name: 'SpecialAgents'
+                },
+                {
+                    name: 'Administrators'
+                }
+            ]);
+            const q = await context.model('User').filterAsync({
+                $filter: `groups/name eq 'SpecialAgents' or groups/name eq 'Administrators'`,
+            });
+            const users = await q.getItems();
+            expect(users).toBeTruthy();
+            expect(users.length).toEqual(2);
+        });
+    });
+
+
+    it('should force distinct items using tag filtering', async () => {
+        Object.assign(context, {
+            user: {
+                name: 'alexis.rees@example.com'
+            }
+        });
+        await TestUtils.executeInTransaction(context, async () => {
+            let user = await context.model('User').where('name').equal('lillian.blake@example.com').getTypedItem();
+            await user.property('tags').insert([
+                'SpecialCustomer',
+            ]);
+            user = await context.model('User').where('name').equal('kennedy.pearson@example.com').getTypedItem();
+            await user.property('tags').insert([
+                'SpecialCustomer',
+                'TopCustomer'
+            ]);
+            const q = await context.model('User').filterAsync({
+                $filter: `tags/tag eq 'SpecialCustomer' or tags/tag eq 'TopCustomer'`,
+            });
+            const users = await q.getItems();
+            expect(users).toBeTruthy();
+            expect(users.length).toEqual(2);
+        });
+    });
+
+    it('should force distinct items using nested tag filtering', async () => {
+        Object.assign(context, {
+            user: {
+                name: 'alexis.rees@example.com'
+            }
+        });
+        await TestUtils.executeInTransaction(context, async () => {
+            let user = await context.model('User').where('name').equal('lillian.blake@example.com').getTypedItem();
+            await user.property('tags').insert([
+                'SpecialCustomer',
+            ]);
+            user = await context.model('User').where('name').equal('kennedy.pearson@example.com').getTypedItem();
+            await user.property('tags').insert([
+                'SpecialCustomer',
+                'TopCustomer'
+            ]);
+            const q = await context.model('Order').filterAsync({
+                $filter: `customer/user/tags/tag eq 'SpecialCustomer' or customer/user/tags/tag eq 'TopCustomer'`,
+            });
+            const items = await q.getItems();
+            expect(items).toBeTruthy();
+            expect(items.length).toEqual(3);
+        });
+    });
+
+});


### PR DESCRIPTION
This PR enables getting distinct values when executing an OData query where the parameters contain a reference to a many-to-many association for avoiding returning the same entity multiple times. An example is when using a tag-like attribute to query entities e.g. `$filter=tags/tag eq 'SpecialCustomer' or tags/tag eq 'TopCustomer'` where `tags` contains a collection of tag of a user,  or a many-to-many association between object e.g. `groups/name eq 'SpecialAgents' or groups/name eq 'Administrators'` where the query is trying to get users that are members of SpecialAgents or Administrators group.