### PR TITLE
Convert configuration to es6 classes

### DIFF
--- a/data-application.d.ts
+++ b/data-application.d.ts
@@ -4,8 +4,8 @@ import { IApplication, ConfigurationBase,
 import {DataContext} from "./types";
 
 export declare class DataApplication extends SequentialEventEmitter implements ApplicationBase {
-    constructor(cwd?: string);
-    configuration: ConfigurationBase;    
+    constructor(cwdOrConfig?: string | unknown);
+    readonly configuration: ConfigurationBase;
     useStrategy(serviceCtor: ApplicationServiceConstructor<any>, strategyCtor: ApplicationServiceConstructor<any>): this;
     useService(serviceCtor: ApplicationServiceConstructor<any>): this;
     hasService<T>(serviceCtor: ApplicationServiceConstructor<T>): boolean;

--- a/data-application.js
+++ b/data-application.js
@@ -2,12 +2,14 @@
 var {Args, PathUtils, SequentialEventEmitter} = require('@themost/common');
 var {DataConfiguration} = require('./data-configuration');
 var {DefaultDataContext} = require('./data-context');
+var isObjectLike = require('lodash/isObjectLike');
+const {isObject} = require('node:util');
 /**
  * @class
- * @param {string} cwd - A string which defines application root directory
+ * @param {string|*} cwdOrConfig - A string which defines application root directory or an object which defines application configuration.
  */
 class DataApplication extends SequentialEventEmitter {
-    constructor(cwd) {
+    constructor(cwdOrConfig) {
         super();
         Object.defineProperty(this, '_services', {
             configurable: true,
@@ -15,11 +17,20 @@ class DataApplication extends SequentialEventEmitter {
             writable: false,
             value: {}
         });
+        if (isObjectLike(cwdOrConfig)) {
+            Object.defineProperty(this, 'configuration', {
+                configurable: true,
+                enumerable: false,
+                writable: false,
+                value: new DataConfiguration(cwdOrConfig)
+            });
+            return;
+        }
         Object.defineProperty(this, 'configuration', {
             configurable: true,
             enumerable: false,
             writable: false,
-            value: new DataConfiguration(PathUtils.join(cwd, 'config'))
+            value: new DataConfiguration(PathUtils.join(cwdOrConfig, 'config'))
         });
     }
     hasService(serviceCtor) {

--- a/data-configuration.d.ts
+++ b/data-configuration.d.ts
@@ -60,7 +60,7 @@ export declare interface DataAdapterType {
 }
 
 export declare class DataConfiguration {
-    constructor(configPath: string);
+    constructor(configPathOrSource?: string | unknown);
     static getCurrent(): DataConfiguration;
     static setCurrent(config: DataConfiguration): DataConfiguration;
     static getNamedConfiguration(name: string): DataConfiguration;

--- a/data-configuration.js
+++ b/data-configuration.js
@@ -4,7 +4,6 @@ var Symbol = require('symbol');
 var {TraceUtils} = require('@themost/common');
 var path = require('path');
 var pluralize = require('pluralize');
-var {LangUtils} = require('@themost/common');
 var {Args} = require('@themost/common');
 var {ConfigurationBase} = require('@themost/common');
 var {ConfigurationStrategy} = require('@themost/common');
@@ -118,13 +117,6 @@ function DataTypeConfiguration() {
      * Gets a collection of additional properties of this data type
      * @name DataTypeConfiguration#properties
      * @type {DataTypePropertiesConfiguration}
-     * @example
-     * ...
-     * "properties": {
-     *       "pattern":"^[+]?[0-9]*\\.?[0-9]*$",
-     *       "patternMessage":"The value should be a number greater than zero."
-     *  }
-     * ...
      */
 
     /**
@@ -286,792 +278,780 @@ function AuthSettingsConfiguration() {
     this.loginPage = '/login';
 }
 
-/**
- * @class
- * @classdesc Holds the configuration of data modeling infrastructure
- * @constructor
- * @param {string=} configPath - The root directory of configuration files. The default directory is the ./config under current working directory
- * @augments ConfigurationBase
- *
- */
-function DataConfiguration(configPath) {
-    DataConfiguration.super_.bind(this)(configPath);
-    //use default data configuration strategy
-    this.useStrategy(DataConfigurationStrategy,DataConfigurationStrategy);
-}
-LangUtils.inherits(DataConfiguration, ConfigurationBase);
-/**
- * @returns {DataConfigurationStrategy}
- */
-DataConfiguration.prototype.getDataConfiguration = function() {
-    return this.getStrategy(DataConfigurationStrategy);
-};
-/**
- * @returns {DataConfiguration}
- */
-DataConfiguration.getCurrent = function() {
-    if (DataConfiguration[currentConfiguration] instanceof DataConfiguration) {
-        return DataConfiguration[currentConfiguration]
-    }
-    DataConfiguration[currentConfiguration] = new DataConfiguration();
-    return DataConfiguration[currentConfiguration];
-};
-/**
- * @param {DataConfiguration} config
- * @returns {DataConfiguration}
- */
-DataConfiguration.setCurrent = function(config) {
-    Args.check(config instanceof DataConfiguration, 'Invalid argument. Expected an instance of DataConfiguration class.');
-    DataConfiguration[currentConfiguration] = config;
-    return DataConfiguration[currentConfiguration];
-};
+class DataConfiguration extends ConfigurationBase {
 
-/**
- * @param {string=} name
- */
-DataConfiguration.getNamedConfiguration = function(name) {
-  if (_.isNil(name)) {
-      return DataConfiguration.getCurrent();
-  }
-  Args.notString(name, 'Configuration Name');
-  Args.notEmpty(name, 'Configuration name');
-    if (/^current$/i.test(name)) {
-        return DataConfiguration.getCurrent();
-    }
-    if (_.isNil(DataConfiguration[namedConfigurations])) {
-        DataConfiguration[namedConfigurations] = { };
-    }
-    if (typeof DataConfiguration[namedConfigurations][name] !== 'undefined')
-        return DataConfiguration[namedConfigurations][name];
-    DataConfiguration[namedConfigurations][name] = new DataConfiguration();
-    return DataConfiguration[namedConfigurations][name];
-};
-
-/**
- * @class
- * @constructor
- * @param {ConfigurationBase} config
- * @augments {ConfigurationStrategy}
- */
-function DataConfigurationStrategy(config) {
-
-    DataConfigurationStrategy.super_.bind(this)(config);
-
-    ///register other strategies
-    if (!config.hasStrategy(SchemaLoaderStrategy)) {
-        config.useStrategy(SchemaLoaderStrategy, DefaultSchemaLoaderStrategy);
-    }
-    if (!config.hasStrategy(ModelClassLoaderStrategy)) {
-       config.useStrategy(ModelClassLoaderStrategy, DefaultModelClassLoaderStrategy);
+    constructor(configPath) {
+        super(configPath);
+        //use default data configuration strategy
+        this.useStrategy(DataConfigurationStrategy,DataConfigurationStrategy);
     }
 
-    if (!config.hasStrategy(DataCacheStrategy)) {
-        //process is running under node js
-        if (typeof process !== 'undefined' && process.nextTick) {
-            //add default cache strategy (using node-cache)
-            config.useStrategy(DataCacheStrategy, DefaultDataCacheStrategy);
+    /**
+     * @returns {DataConfigurationStrategy}
+     */
+    getDataConfiguration() {
+        return this.getStrategy(DataConfigurationStrategy);
+    }
+
+    /**
+     * @returns {DataConfiguration}
+     */
+    static getCurrent() {
+        if (DataConfiguration[currentConfiguration] instanceof DataConfiguration) {
+            return DataConfiguration[currentConfiguration]
         }
+        DataConfiguration[currentConfiguration] = new DataConfiguration();
+        return DataConfiguration[currentConfiguration];
     }
 
-    if (!this.getConfiguration().hasSourceAt('adapters')) {
-        this.getConfiguration().setSourceAt('adapters',[]);
+    /**
+     * @param {ConfigurationBase} config
+     * @returns {DataConfiguration}
+     */
+    static setCurrent(config) {
+        Args.check(config instanceof DataConfiguration, 'Invalid argument. Expected an instance of DataConfiguration class.');
+        DataConfiguration[currentConfiguration] = config;
+        return DataConfiguration[currentConfiguration];
     }
 
-    if (!this.getConfiguration().hasSourceAt('adapterTypes')) {
-        this.getConfiguration().setSourceAt('adapterTypes',[]);
+    /**
+     * @param {string=} name
+     */
+    static getNamedConfiguration(name) {
+      if (_.isNil(name)) {
+          return DataConfiguration.getCurrent();
+      }
+      Args.notString(name, 'Configuration Name');
+      Args.notEmpty(name, 'Configuration name');
+        if (/^current$/i.test(name)) {
+            return DataConfiguration.getCurrent();
+        }
+        if (_.isNil(DataConfiguration[namedConfigurations])) {
+            DataConfiguration[namedConfigurations] = { };
+        }
+        if (typeof DataConfiguration[namedConfigurations][name] !== 'undefined')
+            return DataConfiguration[namedConfigurations][name];
+        DataConfiguration[namedConfigurations][name] = new DataConfiguration();
+        return DataConfiguration[namedConfigurations][name];
     }
+}
 
-    if (!this.getConfiguration().hasSourceAt('settings/auth')) {
-        this.getConfiguration().setSourceAt('settings/auth', new AuthSettingsConfiguration());
-    }
+class DataConfigurationStrategy extends ConfigurationStrategy {
 
-    var configAdapterTypes = this.getConfiguration().getSourceAt('adapterTypes');
-    this[adapterTypesProperty] = {};
-    var self = this;
-    //configure adapter types
-    _.forEach(configAdapterTypes, function(x) {
-        //first of all validate module
-        x.invariantName = x.invariantName || 'unknown';
-        x.name = x.name || 'Unknown Data Adapter';
-        var valid = false, adapterModule;
-        if (x.type) {
-            try {
-                if (/^@themost\//.test(x.type)) {
-                    //get require paths
-                    if (require.resolve && require.resolve.paths) {
-                        /**
-                         * get require paths collection
-                         * @type string[]
-                         */
-                        var paths = require.resolve.paths(x.type);
-                        //get execution
-                        var path1 = self.getConfiguration().getExecutionPath();
-                        //loop directories to parent (like classic require)
-                        while (path1) {
-                            //if path does not exist in paths collection
-                            if (paths.indexOf(path.resolve(path1,'node_modules'))<0) {
-                                //add it
-                                paths.push(path.resolve(path1,'node_modules'));
-                                //and check the next path which is going to be resolved
-                                if (path1 === path.resolve(path1,'..')) {
-                                    //if it is the same with the current path break loop
+    constructor(config) {
+
+        super(config);
+
+        ///register other strategies
+        if (!config.hasStrategy(SchemaLoaderStrategy)) {
+            config.useStrategy(SchemaLoaderStrategy, DefaultSchemaLoaderStrategy);
+        }
+        if (!config.hasStrategy(ModelClassLoaderStrategy)) {
+           config.useStrategy(ModelClassLoaderStrategy, DefaultModelClassLoaderStrategy);
+        }
+
+        if (!config.hasStrategy(DataCacheStrategy)) {
+            //process is running under Node.js
+            if (typeof process !== 'undefined' && process.nextTick) {
+                //add default cache strategy (using node-cache)
+                config.useStrategy(DataCacheStrategy, DefaultDataCacheStrategy);
+            }
+        }
+
+        if (!this.getConfiguration().hasSourceAt('adapters')) {
+            this.getConfiguration().setSourceAt('adapters',[]);
+        }
+
+        if (!this.getConfiguration().hasSourceAt('adapterTypes')) {
+            this.getConfiguration().setSourceAt('adapterTypes',[]);
+        }
+
+        if (!this.getConfiguration().hasSourceAt('settings/auth')) {
+            this.getConfiguration().setSourceAt('settings/auth', new AuthSettingsConfiguration());
+        }
+        /**
+         * @type {DataTypeConfiguration[]}
+         */
+        var configAdapterTypes = this.getConfiguration().getSourceAt('adapterTypes');
+        this[adapterTypesProperty] = {};
+        var self = this;
+        //configure adapter types
+        _.forEach(configAdapterTypes, function(x) {
+            //first of all validate module
+            x.invariantName = x.invariantName || 'unknown';
+            x.name = x.name || 'Unknown Data Adapter';
+            var valid = false, adapterModule;
+            if (x.type) {
+                try {
+                    if (/^@themost\//.test(x.type)) {
+                        //get require paths
+                        if (require.resolve && require.resolve.paths) {
+                            /**
+                             * get require paths collection
+                             * @type string[]
+                             */
+                            var paths = require.resolve.paths(x.type);
+                            //get execution
+                            var path1 = self.getConfiguration().getExecutionPath();
+                            //loop directories to parent (like classic require)
+                            while (path1) {
+                                //if path does not exist in paths collection
+                                if (paths.indexOf(path.resolve(path1,'node_modules'))<0) {
+                                    //add it
+                                    paths.push(path.resolve(path1,'node_modules'));
+                                    //and check the next path which is going to be resolved
+                                    if (path1 === path.resolve(path1,'..')) {
+                                        //if it is the same with the current path break loop
+                                        break;
+                                    }
+                                    //otherwise get parent path
+                                    path1 = path.resolve(path1,'..');
+                                }
+                                else {
+                                    //path already exists in paths collection, so break loop
                                     break;
                                 }
-                                //otherwise get parent path
-                                path1 = path.resolve(path1,'..');
                             }
-                            else {
-                                //path already exists in paths collection, so break loop
-                                break;
-                            }
+                            var adapterModulePath = require.resolve(x.type, {
+                                paths:paths
+                            });
+                            adapterModule = require(adapterModulePath);
                         }
-                        var adapterModulePath = require.resolve(x.type, {
-                            paths:paths
-                        });
-                        adapterModule = require(adapterModulePath);
+                        else {
+                            adapterModule = require(x.type);
+                        }
                     }
                     else {
                         adapterModule = require(x.type);
                     }
-                }
-                else {
-                    adapterModule = require(x.type);
-                }
 
-                if (typeof adapterModule.createInstance === 'function') {
-                    valid = true;
+                    if (typeof adapterModule.createInstance === 'function') {
+                        valid = true;
+                    }
+                    else {
+                        //adapter type does not export a createInstance(options) function
+                        TraceUtils.log('The specified data adapter type (%s) does not have the appropriate constructor. Adapter type cannot be loaded.', x.invariantName);
+                    }
                 }
-                else {
-                    //adapter type does not export a createInstance(options) function
-                    TraceUtils.log('The specified data adapter type (%s) does not have the appropriate constructor. Adapter type cannot be loaded.', x.invariantName);
+                catch(err) {
+                    //catch error
+                    TraceUtils.error(err);
+                    //and log a specific error for this adapter type
+                    TraceUtils.log('The specified data adapter type (%s) cannot be instantiated. Adapter type cannot be loaded.', x.invariantName);
+                }
+                if (valid) {
+                    //register adapter
+                    self[adapterTypesProperty][x.invariantName] = {
+                        invariantName:x.invariantName,
+                        name: x.name,
+                        createInstance:adapterModule.createInstance
+                    };
                 }
             }
-            catch(err) {
-                //catch error
-                TraceUtils.error(err);
-                //and log a specific error for this adapter type
-                TraceUtils.log('The specified data adapter type (%s) cannot be instantiated. Adapter type cannot be loaded.', x.invariantName);
+            else {
+                TraceUtils.log('The specified data adapter type (%s) does not have a type defined. Adapter type cannot be loaded.', x.invariantName);
             }
-            if (valid) {
-                //register adapter
-                self[adapterTypesProperty][x.invariantName] = {
-                    invariantName:x.invariantName,
-                    name: x.name,
-                    createInstance:adapterModule.createInstance
-                };
-            }
-        }
-        else {
-            TraceUtils.log('The specified data adapter type (%s) does not have a type defined. Adapter type cannot be loaded.', x.invariantName);
-        }
-    });
+        });
 
-    /**
-     * @name DataConfigurationStrategy#dataTypes
-     * @type {Object.<string,DataTypeConfiguration>}
-     */
+        /**
+         * @name DataConfigurationStrategy#dataTypes
+         * @type {Object.<string,DataTypeConfiguration>}
+         */
 
-    Object.defineProperty(this,'dataTypes', {
-        get:function() {
-            if (this[dataTypesProperty]) {
-                return this[dataTypesProperty];
-            }
-            //get data types from configuration file
-            try {
-                var dataTypes = require(path.join(this.getConfiguration().getConfigurationPath(), 'dataTypes.json'));
-                if (_.isNil(dataTypes)) {
-                    TraceUtils.log('Data: Application data types are empty. The default data types will be loaded instead.');
-                    dataTypes = require('./dataTypes.json');
+        Object.defineProperty(this,'dataTypes', {
+            get:function() {
+                if (this[dataTypesProperty]) {
+                    return this[dataTypesProperty];
                 }
-                else {
-                    //append default data types which are not defined in application data types
-                    var defaultDataTypes = require('./dataTypes.json');
-                    //enumerate default data types and replace or append application specific data types
-                    _.forEach(_.keys(defaultDataTypes), function(key) {
-                        if (hasOwnProperty(dataTypes, key)) {
-                            if (dataTypes[key].version) {
-                                if (dataTypes[key].version <= defaultDataTypes[key].version) {
-                                    //replace data type due to lower version
+                //get data types from configuration file
+                try {
+                    var dataTypes = require(path.join(this.getConfiguration().getConfigurationPath(), 'dataTypes.json'));
+                    if (_.isNil(dataTypes)) {
+                        TraceUtils.log('Data: Application data types are empty. The default data types will be loaded instead.');
+                        dataTypes = require('./dataTypes.json');
+                    }
+                    else {
+                        //append default data types which are not defined in application data types
+                        var defaultDataTypes = require('./dataTypes.json');
+                        //enumerate default data types and replace or append application specific data types
+                        _.forEach(_.keys(defaultDataTypes), function(key) {
+                            if (hasOwnProperty(dataTypes, key)) {
+                                if (dataTypes[key].version) {
+                                    if (dataTypes[key].version <= defaultDataTypes[key].version) {
+                                        //replace data type due to lower version
+                                        dataTypes[key] = defaultDataTypes[key];
+                                    }
+                                }
+                                else {
+                                    //replace data type due to invalid version
                                     dataTypes[key] = defaultDataTypes[key];
                                 }
                             }
                             else {
-                                //replace data type due to invalid version
+                                //append data type
                                 dataTypes[key] = defaultDataTypes[key];
                             }
-                        }
-                        else {
-                            //append data type
-                            dataTypes[key] = defaultDataTypes[key];
-                        }
-                    });
+                        });
+                    }
                 }
+                catch(err) {
+                    if (err.code === 'MODULE_NOT_FOUND') {
+                        TraceUtils.log('Data: Application specific data types are missing. The default data types will be loaded instead.');
+                    }
+                    else {
+                        TraceUtils.log('Data: An error occurred while loading application data types.');
+                        throw err;
+                    }
+                    dataTypes = require('./dataTypes.json');
+                }
+                this[dataTypesProperty] = dataTypes;
+                return this[dataTypesProperty];
+
             }
-            catch(err) {
-                if (err.code === 'MODULE_NOT_FOUND') {
-                    TraceUtils.log('Data: Application specific data types are missing. The default data types will be loaded instead.');
-                }
-                else {
-                    TraceUtils.log('Data: An error occurred while loading application data types.');
-                    throw err;
-                }
-                dataTypes = require('./dataTypes.json');
+        });
+
+        /**
+         * @name DataConfigurationStrategy#adapters
+         * @type {Array.<DataAdapterConfiguration>}
+         */
+
+        Object.defineProperty(this,'adapters', {
+            get:function() {
+                return this.getConfiguration().getSourceAt('adapters');
             }
-            this[dataTypesProperty] = dataTypes;
-            return this[dataTypesProperty];
+        });
 
-        }
-    });
+        /**
+         * @name DataConfigurationStrategy#adapterTypes
+         * @type {*}
+         */
+
+        Object.defineProperty(this,'adapterTypes', {
+            get:function() {
+                return this[adapterTypesProperty];
+            }
+        });
+
+
+    }
 
     /**
-     * @name DataConfigurationStrategy#adapters
-     * @type {Array.<DataAdapterConfiguration>}
+     * @returns {AuthSettingsConfiguration|*}
      */
-
-    Object.defineProperty(this,'adapters', {
-        get:function() {
-            return this.getConfiguration().getSourceAt('adapters');
-        }
-    });
+    getAuthSettings() {
+        return this.getConfiguration().getSourceAt('settings/auth');
+    }
 
     /**
-     * @name DataConfigurationStrategy#adapterTypes
-     * @type {*}
+     * @param {string} invariantName
+     * @returns {*}
      */
+    getAdapterType(invariantName) {
+        return this[adapterTypesProperty][invariantName];
+    }
 
-    Object.defineProperty(this,'adapterTypes', {
-        get:function() {
-            return this[adapterTypesProperty];
+    /**
+     * Gets a boolean which indicates whether the specified data type is defined in data types collection or not.
+     * @param name
+     * @returns {boolean}
+     */
+    hasDataType(name) {
+        if (_.isNil(name)) {
+            return false;
         }
-    });
+        if (typeof name !== 'string') {
+            return false;
+        }
+        return hasOwnProperty(this.dataTypes, name);
+    }
 
+    /**
+     * Gets a native object which represents the definition of the model with the given name.
+     * @param {string} name
+     * @returns {*}
+     */
+    getModelDefinition(name) {
+        /**
+         * @type {SchemaLoaderStrategy}
+         */
+        var schemaLoader = this.getConfiguration().getStrategy(SchemaLoaderStrategy);
+        return schemaLoader.getModelDefinition(name);
+    }
 
+    /**
+     * Gets a native object which represents the definition of the model with the given name.
+     * @param {*} data
+     * @returns {DataConfigurationStrategy}
+     */
+    setModelDefinition(data) {
+        /**
+         * @type {SchemaLoaderStrategy}
+         */
+        var schemaLoader = this.getConfiguration().getStrategy(SchemaLoaderStrategy);
+        schemaLoader.setModelDefinition(data);
+        return this;
+    }
+
+    /**
+     * @returns {*}
+     * @param name {string}
+     */
+    model(name) {
+        return this.getModelDefinition(name);
+    }
+
+    /**
+     * Gets the current data configuration
+     * @returns DataConfigurationStrategy - An instance of DataConfiguration class which represents the current data configuration
+     */
+    static getCurrent() {
+        var configuration = ConfigurationBase.getCurrent();
+        if (!configuration.hasStrategy(DataConfigurationStrategy)) {
+            configuration.useStrategy(DataConfigurationStrategy, DataConfigurationStrategy);
+        }
+        return configuration.getStrategy(DataConfigurationStrategy);
+    }
 }
-LangUtils.inherits(DataConfigurationStrategy,ConfigurationStrategy);
 
-/**
- * @returns {AuthSettingsConfiguration|*}
- */
-DataConfigurationStrategy.prototype.getAuthSettings = function() {
-    return this.getConfiguration().getSourceAt('settings/auth');
-};
-
-
-/**
- * @param {string} invariantName
- * @returns {*}
- */
-DataConfigurationStrategy.prototype.getAdapterType = function(invariantName) {
-    return this[adapterTypesProperty][invariantName];
-};
-
-/**
- * Gets a boolean which indicates whether the specified data type is defined in data types collection or not.
- * @param name
- * @returns {boolean}
- */
-DataConfigurationStrategy.prototype.hasDataType = function(name) {
-    if (_.isNil(name)) {
-        return false;
-    }
-    if (typeof name !== 'string') {
-        return false;
-    }
-    return hasOwnProperty(this.dataTypes, name);
-};
-
-/**
- * Gets a native object which represents the definition of the model with the given name.
- * @param {string} name
- * @returns {*}
- */
-DataConfigurationStrategy.prototype.getModelDefinition = function(name) {
+class SchemaLoaderStrategy extends ConfigurationStrategy {
     /**
-     * @type {SchemaLoaderStrategy}
+     * @class
+     * @constructor
+     * @param {ConfigurationBase} config
+     * @augments ConfigurationStrategy
      */
-    var schemaLoader = this.getConfiguration().getStrategy(SchemaLoaderStrategy);
-    return schemaLoader.getModelDefinition(name);
-};
+    constructor(config) {
+        super(config);
+        this[modelsProperty] = {};
+        this.setModelDefinition({
+            'name':'Migration', 'title':'Data Model Migrations', 'id': 14,
+            'source':'migrations', 'view':'migrations', 'hidden': true, 'sealed':true,
+            'fields':[
+                { 'name':'id', 'type':'Counter', 'primary':true },
+                { 'name':'appliesTo', 'type':'Text', 'size':180, 'nullable':false },
+                { 'name':'model', 'type':'Text', 'size':120 },
+                { 'name':'description', 'type':'Text', 'size':512},
+                { 'name':'version', 'type':'Text', 'size':40, 'nullable':false }
+            ],
+            'constraints':[
+                { 'type':'unique', 'fields':[ 'appliesTo', 'version' ] }
+            ]
+        });
 
-/**
- * Gets a native object which represents the definition of the model with the given name.
- * @param {*} data
- * @returns {DataConfigurationStrategy}
- */
-DataConfigurationStrategy.prototype.setModelDefinition = function(data) {
-    /**
-     * @type {SchemaLoaderStrategy}
-     */
-    var schemaLoader = this.getConfiguration().getStrategy(SchemaLoaderStrategy);
-    schemaLoader.setModelDefinition(data);
-    return this;
-};
-
-/**
- * @returns {*}
- * @param name {string}
- */
-DataConfigurationStrategy.prototype.model = function(name) {
-    return this.getModelDefinition(name);
-};
-
-/**
- * Gets the current data configuration
- * @returns DataConfigurationStrategy - An instance of DataConfiguration class which represents the current data configuration
- */
-DataConfigurationStrategy.getCurrent = function() {
-    var configuration = ConfigurationBase.getCurrent();
-    if (!configuration.hasStrategy(DataConfigurationStrategy)) {
-        configuration.useStrategy(DataConfigurationStrategy, DataConfigurationStrategy);
     }
-    return configuration.getStrategy(DataConfigurationStrategy);
-};
 
-
-/**
- * @class
- * @constructor
- * @param {ConfigurationBase} config
- * @augments ConfigurationStrategy
- */
-function SchemaLoaderStrategy(config) {
-    SchemaLoaderStrategy.super_.bind(this)(config);
-    this[modelsProperty] = {};
-    this.setModelDefinition({
-        'name':'Migration', 'title':'Data Model Migrations', 'id': 14,
-        'source':'migrations', 'view':'migrations', 'hidden': true, 'sealed':true,
-        'fields':[
-            { 'name':'id', 'type':'Counter', 'primary':true },
-            { 'name':'appliesTo', 'type':'Text', 'size':180, 'nullable':false },
-            { 'name':'model', 'type':'Text', 'size':120 },
-            { 'name':'description', 'type':'Text', 'size':512},
-            { 'name':'version', 'type':'Text', 'size':40, 'nullable':false }
-        ],
-        'constraints':[
-            { 'type':'unique', 'fields':[ 'appliesTo', 'version' ] }
-        ]
-    });
-    
-}
-LangUtils.inherits(SchemaLoaderStrategy,ConfigurationStrategy);
-
-/**
- * Gets a model definition
- * @param {string} name
- * @returns {*}
- */
-SchemaLoaderStrategy.prototype.getModelDefinition = function(name) {
-    Args.notString(name,'Model name');
-    var result = this[modelsProperty][name];
-    if (typeof result !== 'undefined') {
+    /**
+     * Gets a model definition
+     * @param {string} name
+     * @returns {*}
+     */
+    getModelDefinition(name) {
+        Args.notString(name,'Model name');
+        var result = this[modelsProperty][name];
+        if (typeof result !== 'undefined') {
+            return result;
+        }
+        var re = new RegExp('^'+name+'$','ig');
+        result = _.find(_.keys(this[modelsProperty]), function(x) {
+            return re.test(x);
+        });
         return result;
     }
-    var re = new RegExp('^'+name+'$','ig');
-    result = _.find(_.keys(this[modelsProperty]), function(x) {
-        return re.test(x);
-    });
-    return result;
-};
-/**
- * Sets a model definition
- * @param {*} data
- * @returns {SchemaLoaderStrategy}
- */
-SchemaLoaderStrategy.prototype.setModelDefinition = function(data) {
-    if (data == null) {
-        throw new Error('Invalid model definition. Expected object.')
-    }
-    if (typeof data === 'object') {
-        if (typeof data.name === 'undefined' || data.name === null) {
-            throw new Error('Invalid model definition. Expected model name.')
+
+    /**
+     * Sets a model definition
+     * @param {*} data
+     * @returns {SchemaLoaderStrategy}
+     */
+    setModelDefinition(data) {
+        if (data == null) {
+            throw new Error('Invalid model definition. Expected object.')
         }
-        this[modelsProperty][data.name] = data;
+        if (typeof data === 'object') {
+            if (typeof data.name === 'undefined' || data.name === null) {
+                throw new Error('Invalid model definition. Expected model name.')
+            }
+            this[modelsProperty][data.name] = data;
+        }
+        return this;
     }
-    return this;
-};
-/**
- * Gets an array of strings which represents the loaded models
- * @returns {Array.<string>}
- */
-SchemaLoaderStrategy.prototype.getModels = function() {
-    return _.keys(this[modelsProperty]);
-};
-/**
- * @abstract
- * @returns Array<string>
- */
-SchemaLoaderStrategy.prototype.readSync = function() {
-    throw new AbstractMethodError();
-};
-/**
- * @class
- * @constructor
- * @param {ConfigurationBase} config
- * @augments ConfigurationStrategy
- */
-function FileSchemaLoaderStrategy(config) {
-    FileSchemaLoaderStrategy.super_.bind(this)(config);
-    // set default path for *.json schemas
-    this[modelPathProperty] = PathUtils.join(config.getConfigurationPath(), 'models');
+
     /**
-     * @type {DefaultSchemaLoaderStrategyOptions}
+     * Gets an array of strings which represents the loaded models
+     * @returns {Array.<string>}
      */
-    var schemaOptions = config.getSourceAt('settings/schema');
+    getModels() {
+        return _.keys(this[modelsProperty]);
+    }
+
     /**
-     * set default options
-     * @type {DefaultSchemaLoaderStrategyOptions}
+     * @abstract
+     * @returns Array<string>
      */
-    this.options = {
-        usePlural: true
-    };
-    // get only DefaultSchemaLoaderStrategyOptions.usePlural if exists
-    if (schemaOptions && hasOwnProperty(schemaOptions, 'usePlural')) {
-        this.options.usePlural = schemaOptions.usePlural;
+    readSync() {
+        throw new AbstractMethodError();
     }
 }
-LangUtils.inherits(FileSchemaLoaderStrategy,SchemaLoaderStrategy);
 
-/**
- * Gets a string which represents the directory which contains model definitions.
- * @returns {string}
- */
-FileSchemaLoaderStrategy.prototype.getModelPath = function() {
-    return this[modelPathProperty];
-};
-/**
- * Reads available schemas
- * @returns {Array<string>}
- */
-FileSchemaLoaderStrategy.prototype.readSync = function() {
-    // load native fs module
-    var nativeFsModule = 'fs';
-    var modelPath = this.getModelPath();
-    var fs = require(nativeFsModule);
-    var files = [];
-    // read directory
-    if (typeof fs.readdirSync === 'function') {
-        var dirExists = true;
-        if (typeof fs.existsSync === 'function') {
-            dirExists = fs.existsSync(modelPath);
-        }
-        if (dirExists) {
-            // set files property
-            files = _.map(_.filter(fs.readdirSync(modelPath), function(file) {
-                // filter *.json files
-                return /\.json$/i.test(file);
-            }), function(file) {
-                //strip file extension
-                return file.replace(/\.json$/i, '');
-            });
+class FileSchemaLoaderStrategy extends SchemaLoaderStrategy {
+    constructor(config) {
+        super(config);
+        // set default path for *.json schemas
+        this[modelPathProperty] = PathUtils.join(config.getConfigurationPath(), 'models');
+        /**
+         * @type {DefaultSchemaLoaderStrategyOptions}
+         */
+        var schemaOptions = config.getSourceAt('settings/schema');
+        /**
+         * set default options
+         * @type {DefaultSchemaLoaderStrategyOptions}
+         */
+        this.options = {
+            usePlural: true
+        };
+        // get only DefaultSchemaLoaderStrategyOptions.usePlural if exists
+        if (schemaOptions && hasOwnProperty(schemaOptions, 'usePlural')) {
+            this.options.usePlural = schemaOptions.usePlural;
         }
     }
-    // return collection of schemas
-    return files;
-};
 
-/**
- * Sets the directory of model definitions.
- * @param {string} p
- * @returns {DefaultSchemaLoaderStrategy}
- */
-FileSchemaLoaderStrategy.prototype.setModelPath = function(p) {
-    this[modelPathProperty] = p;
-    return this;
-};
+    /**
+     * Gets a string which represents the directory which contains model definitions.
+     * @returns {string}
+     */
+    getModelPath() {
+        return this[modelPathProperty];
+    }
 
-/**
- * Gets a model definition
- * @param {string} name
- * @returns {*}
- */
-FileSchemaLoaderStrategy.prototype.getModelDefinition = function(name) {
-    var getModelDefinitionSuper = FileSchemaLoaderStrategy.super_.prototype.getModelDefinition;
-    var i;
-    if (typeof name !== 'string')
-        return;
-    //exclude registered data types
-    if (this.getConfiguration().getStrategy(DataConfigurationStrategy).hasDataType(name)) {
-        return;
+    /**
+     * Reads available schemas
+     * @returns {Array<string>}
+     */
+    readSync() {
+        // load native fs module
+        var nativeFsModule = 'fs';
+        var modelPath = this.getModelPath();
+        var fs = require(nativeFsModule);
+        var files = [];
+        // read directory
+        if (typeof fs.readdirSync === 'function') {
+            var dirExists = true;
+            if (typeof fs.existsSync === 'function') {
+                dirExists = fs.existsSync(modelPath);
+            }
+            if (dirExists) {
+                // set files property
+                files = _.map(_.filter(fs.readdirSync(modelPath), function(file) {
+                    // filter *.json files
+                    return /\.json$/i.test(file);
+                }), function(file) {
+                    //strip file extension
+                    return file.replace(/\.json$/i, '');
+                });
+            }
+        }
+        // return collection of schemas
+        return files;
     }
-    var modelDefinition = getModelDefinitionSuper.bind(this)(name);
-    //first of all try to find if model definition is already in cache
-    if (modelDefinition) {
-        //and return it
-        return modelDefinition;
+
+    /**
+     * Sets the directory of model definitions.
+     * @param {string} p
+     */
+    setModelPath(p) {
+        this[modelPathProperty] = p;
+        return this;
     }
-    // hold singular name of
-    var singularName;
-    if (this.options.usePlural &&  pluralize.isPlural(name)) {
-        // try to find model based on singular name
-        singularName = pluralize.singular(name);
-        // call super func
-        modelDefinition = getModelDefinitionSuper.bind(this)(singularName);
+
+    /**
+     * Gets a model definition
+     * @param {string} name
+     * @returns {*}
+     */
+    getModelDefinition(name) {
+        var getModelDefinitionSuper = super.getModelDefinition;
+        var i;
+        if (typeof name !== 'string')
+            return;
+        //exclude registered data types
+        if (this.getConfiguration().getStrategy(DataConfigurationStrategy).hasDataType(name)) {
+            return;
+        }
+        var modelDefinition = getModelDefinitionSuper.bind(this)(name);
+        //first of all try to find if model definition is already in cache
         if (modelDefinition) {
             //and return it
             return modelDefinition;
         }
-    }
-    if (this[filesProperty] == null) {
-        this[filesProperty] = this.readSync().map( file => {
-            return file.concat('.json')
-        });
-    }
-    /**
-     * @type Array<string>
-     */
-    var files = this[filesProperty];
-    if (files.length===0) {
-        return;
-    }
-    var modelPath = this.getModelPath();
-    var searchName;
-    if (singularName) {
-        // search for singular name also e.g. ^(User|Users)\.json$
-        searchName = new RegExp('^(' + singularName + '|' + name + ')\\.json$','i');
-    }
-    else {
-        // otherwise search for name e.g. ^User\.json$
-        searchName = new RegExp('^' + name + '\\.json$','i');
-    }
-    for (i = 0; i < files.length; i++) {
-        searchName.lastIndex=0;
-        if (searchName.test(files[i])) {
-            // build model file path
-            var finalPath = PathUtils.join(modelPath, files[i]);
-            // get model
-            var result = require(finalPath);
-            // clone
-            var finalResult = _.cloneDeep(result);
-            // clone and set definition
-            this.setModelDefinition(finalResult);
-            // return this definition
-            return finalResult;
-        }
-    }
-};
-
-/**
- * @class
- * @constructor
- * @param {ConfigurationBase} config
- * @augments ConfigurationStrategy
- */
-function DefaultSchemaLoaderStrategy(config) {
-    DefaultSchemaLoaderStrategy.super_.bind(this)(config);
-    this[modelPathProperty] = PathUtils.join(config.getConfigurationPath(), 'models');
-    /**
-     * @type {Array<SchemaLoaderStrategy>}
-     */
-    this.loaders = [];
-    /**
-     * get loaders from configuration
-     * @type {DefaultSchemaLoaderStrategyOptions}
-     * @example
-     * [
-     *      {
-     *          "loaderType": "any-library#CustomSchemaLoader"
-     *      },
-     *      {
-     *          "loaderType": "another-library#AnotherSchemaLoader"
-     *      }
-     * ]
-     */
-    var schemaOptions = config.getSourceAt('settings/schema');
-    /**
-     * prepare options
-     * @type {DefaultSchemaLoaderStrategyOptions}
-     */
-    this.options = _.assign({}, {
-        usePlural: true
-    }, schemaOptions);
-    // set loaders
-    var thisArg = this;
-    // if configuration has a collection of loaders
-    if (this.options.loaders && this.options.loaders.length) {
-        // get module loader service
-        var moduleLoader = config.getStrategy(ModuleLoader);
-        if (moduleLoader == null) {
-            moduleLoader = new DefaultModuleLoader(config.getExecutionPath());
-        }
-        // enumerate loader types
-        _.forEach(this.options.loaders, function(x) {
-            // if loader has a hash e.g. ./lib/index#AnotherLoader
-            var hashIndex = x.loaderType.indexOf('#');
-            if (hashIndex>-1) {
-                // get loader module
-                var typeModule = moduleLoader.require(x.loaderType.substr(0,hashIndex));
-                // get loader constructor
-                var typeCtor = x.loaderType.substr(hashIndex+1,x.loaderType.length-hashIndex);
-                // if module exports loader constructor
-                if (hasOwnProperty(typeModule, typeCtor)) {
-                    var LoaderCtor = typeModule[typeCtor];
-                    // add loader to collection
-                    thisArg.loaders.push(new LoaderCtor(config));
-                }
-            }
-            else {
-                // simply add module to collection of loaders
-                // we assume that module exports the required methods
-                // and acts like an instance of SchemaLoader class
-                thisArg.loaders.push(moduleLoader.require(x.loaderType));
-            }
-        });
-    }
-
-}
-LangUtils.inherits(DefaultSchemaLoaderStrategy,FileSchemaLoaderStrategy);
-
-/**
- * Gets a model definition
- * @param {string} name
- * @returns {*}
- */
-DefaultSchemaLoaderStrategy.prototype.getModelDefinition = function(name) {
-    // get super class method
-    var getModelDefinitionSuper = DefaultSchemaLoaderStrategy.super_.prototype.getModelDefinition;
-    // execute method
-    var model =  getModelDefinitionSuper.bind(this)(name);
-    // if model is missing
-    if (model == null) {
-        // try to load model from alternative loaders if any
-        if (this.loaders && this.loaders.length) {
-            for (let i = 0; i < this.loaders.length; i++) {
-                /**
-                 * @type {SchemaLoaderStrategy}
-                 */
-                var loader = this.loaders[i];
-                // try to get model
-                model = loader.getModelDefinition(name);
-                // if model exists
-                if (model != null) {
-                    // set model definition to avoid searching loaders again
-                    this.setModelDefinition(model);
-                    // and return
-                    return model;
-                }
+        // hold singular name of
+        var singularName;
+        if (this.options.usePlural &&  pluralize.isPlural(name)) {
+            // try to find model based on singular name
+            singularName = pluralize.singular(name);
+            // call super func
+            modelDefinition = getModelDefinitionSuper.bind(this)(singularName);
+            if (modelDefinition) {
+                //and return it
+                return modelDefinition;
             }
         }
-    }
-    return model;
-};
-/**
- * @class
- * @constructor
- * @param {ConfigurationBase} config
- * @augments ConfigurationStrategy
- */
-function ModelClassLoaderStrategy(config) {
-    ModelClassLoaderStrategy.super_.bind(this)(config);
-}
-LangUtils.inherits(ModelClassLoaderStrategy,ConfigurationStrategy);
-
-/**
- * @param {DataModel} model
- * @returns {DataObjectConstructor}
- */
-// eslint-disable-next-line no-unused-vars
-ModelClassLoaderStrategy.prototype.resolve = function(model) {
-    throw new AbstractMethodError();
-};
-
-/**
- * @class
- * @constructor
- * @param {ConfigurationBase} config
- * @augments ModelClassLoaderStrategy
- */
-function DefaultModelClassLoaderStrategy(config) {
-    DefaultModelClassLoaderStrategy.super_.bind(this)(config);
-}
-LangUtils.inherits(DefaultModelClassLoaderStrategy,ModelClassLoaderStrategy);
-
-/**
- * @param {*} model
- * @returns {DataObjectConstructor}
- */
-DefaultModelClassLoaderStrategy.prototype.resolve = function(model) {
-    Args.notNull(model, 'Model');
-    var dataObjectClassProperty = 'DataObjectClass';
-    // get data object class from the given model
-    var DataObjectClass = model.DataObjectClass;
-    // if DataObjectClass is a constructor
-    if (typeof DataObjectClass === 'function') {
-        return DataObjectClass;
-    }
-    // get model definition
-    var modelDefinition = this.getConfiguration().getStrategy(SchemaLoaderStrategy).getModelDefinition(model.name);
-    var executionPath = this.getConfiguration().getExecutionPath();
-    // noinspection ExceptionCaughtLocallyJS
-    if (typeof model.classPath === 'string') {
-        if (/^\.\//.test(model.classPath)) {
-            modelDefinition[dataObjectClassProperty] = DataObjectClass = interopRequireDefault(PathUtils.join(executionPath, model.classPath));
+        if (this[filesProperty] == null) {
+            this[filesProperty] = this.readSync().map( file => {
+                return file.concat('.json')
+            });
+        }
+        /**
+         * @type Array<string>
+         */
+        var files = this[filesProperty];
+        if (files.length===0) {
+            return;
+        }
+        var modelPath = this.getModelPath();
+        var searchName;
+        if (singularName) {
+            // search for singular name also e.g. ^(User|Users)\.json$
+            searchName = new RegExp('^(' + singularName + '|' + name + ')\\.json$','i');
         }
         else {
-            modelDefinition[dataObjectClassProperty] = DataObjectClass = interopRequireDefault(model.classPath);
+            // otherwise search for name e.g. ^User\.json$
+            searchName = new RegExp('^' + name + '\\.json$','i');
+        }
+        for (i = 0; i < files.length; i++) {
+            searchName.lastIndex=0;
+            if (searchName.test(files[i])) {
+                // build model file path
+                var finalPath = PathUtils.join(modelPath, files[i]);
+                // get model
+                var result = require(finalPath);
+                // clone
+                var finalResult = _.cloneDeep(result);
+                // clone and set definition
+                this.setModelDefinition(finalResult);
+                // return this definition
+                return finalResult;
+            }
         }
     }
-    else {
-        var requireModules = [
-            // e.g. ./models/OrderDetail
-            PathUtils.join(executionPath, 'models', model.name), 
-            // e.g. ./models/OrderDetailModel
-            PathUtils.join(executionPath,'models', model.name.concat('Model')),
-            // e.g. ./models/order-detail-model
-            PathUtils.join(executionPath,'models',_.dasherize(model.name).concat('-model')),
-            // e.g. ./models/order-detail.model
-            PathUtils.join(executionPath,'models',_.dasherize(model.name).concat('.model')),
-        ];
-        for (var requiredModule of requireModules) {
-            try {
-                var module = require(requiredModule);
-                // try to find if module has an exported member with name equal to this model name
-                if (hasOwnProperty(module, model.name) && typeof module[model.name] === 'function') {
-                    modelDefinition[dataObjectClassProperty] = DataObjectClass = module[model.name];
-                } else if (hasOwnProperty(module, '__esModule') && typeof module.default === 'function') {
-                    // try to find the default export
-                    modelDefinition[dataObjectClassProperty] = DataObjectClass = module.default;
-                } else if (typeof module === 'function') {
-                    // otherwise validate module
-                    modelDefinition[dataObjectClassProperty] = DataObjectClass = module;
-                }
-                if (DataObjectClass != null) {
-                    return DataObjectClass;
-                }
-                // and throw error if module has an invalid format
-                var error = Object.assign(new Error('Data model class module is invalid. Expected a class to be exported as default or named member'),
-                {
-                    code: 'MODULE_INVALID',
-                    module: requiredModule
-                });
-                throw error;
-            } catch (err) {
-                if (err.code !== 'MODULE_NOT_FOUND') {
-                    throw err;
-                }
-                // otherwise, continue
-            }
-        }
-        // check if model inherits another model and return its class
-        if (model.inherits != null) {
-            var inheritedModel = model.context.model(model.inherits);
-            if (inheritedModel == null) {
-                throw new Error('Inherited model cannot be found');
-            }
-            modelDefinition[dataObjectClassProperty] = DataObjectClass = this.resolve(inheritedModel);
-        } else if (model.implements != null) {
-            var implementedModel = model.context.model(model.implements);
-            if (implementedModel == null) {
-                throw new Error('Implemented model cannot be found');
-            }
-            modelDefinition[dataObjectClassProperty] = DataObjectClass = this.resolve(implementedModel);
+}
 
-        } else {
-            // finally, return DataObject
-            modelDefinition[dataObjectClassProperty] = DataObjectClass = require('./data-object').DataObject;
+class DefaultSchemaLoaderStrategy extends FileSchemaLoaderStrategy {
+
+    constructor(config) {
+        super(config);
+        this[modelPathProperty] = PathUtils.join(config.getConfigurationPath(), 'models');
+        /**
+         * @type {Array<SchemaLoaderStrategy>}
+         */
+        this.loaders = [];
+        /**
+         * get loaders from configuration
+         * @type {DefaultSchemaLoaderStrategyOptions}
+         * @example
+         * [
+         *      {
+         *          "loaderType": "any-library#CustomSchemaLoader"
+         *      },
+         *      {
+         *          "loaderType": "another-library#AnotherSchemaLoader"
+         *      }
+         * ]
+         */
+        var schemaOptions = config.getSourceAt('settings/schema');
+        /**
+         * prepare options
+         * @type {DefaultSchemaLoaderStrategyOptions}
+         */
+        this.options = _.assign({}, {
+            usePlural: true
+        }, schemaOptions);
+        // set loaders
+        var thisArg = this;
+        // if configuration has a collection of loaders
+        if (this.options.loaders && this.options.loaders.length) {
+            // get module loader service
+            var moduleLoader = config.getStrategy(ModuleLoader);
+            if (moduleLoader == null) {
+                moduleLoader = new DefaultModuleLoader(config.getExecutionPath());
+            }
+            // enumerate loader types
+            _.forEach(this.options.loaders, function(x) {
+                // if loader has a hash e.g. ./lib/index#AnotherLoader
+                var hashIndex = x.loaderType.indexOf('#');
+                if (hashIndex>-1) {
+                    // get loader module
+                    var typeModule = moduleLoader.require(x.loaderType.substr(0,hashIndex));
+                    // get loader constructor
+                    var typeCtor = x.loaderType.substr(hashIndex+1,x.loaderType.length-hashIndex);
+                    // if module exports loader constructor
+                    if (hasOwnProperty(typeModule, typeCtor)) {
+                        var LoaderCtor = typeModule[typeCtor];
+                        // add loader to collection
+                        thisArg.loaders.push(new LoaderCtor(config));
+                    }
+                }
+                else {
+                    // simply add module to collection of loaders
+                    // we assume that module exports the required methods
+                    // and acts like an instance of SchemaLoader class
+                    thisArg.loaders.push(moduleLoader.require(x.loaderType));
+                }
+            });
         }
+
     }
-    return DataObjectClass;
-};
+
+    /**
+     * Gets a model definition
+     * @param {string} name
+     * @returns {*}
+     */
+    getModelDefinition(name) {
+        // get super class method
+        var getModelDefinitionSuper = super.getModelDefinition;
+        // execute method
+        var model =  getModelDefinitionSuper.bind(this)(name);
+        // if model is missing
+        if (model == null) {
+            // try to load model from alternative loaders if any
+            if (this.loaders && this.loaders.length) {
+                for (let i = 0; i < this.loaders.length; i++) {
+                    /**
+                     * @type {SchemaLoaderStrategy}
+                     */
+                    var loader = this.loaders[i];
+                    // try to get model
+                    model = loader.getModelDefinition(name);
+                    // if model exists
+                    if (model != null) {
+                        // set model definition to avoid searching loaders again
+                        this.setModelDefinition(model);
+                        // and return
+                        return model;
+                    }
+                }
+            }
+        }
+        return model;
+    }
+}
+
+class ModelClassLoaderStrategy extends ConfigurationStrategy {
+    /**
+     * @class
+     * @constructor
+     * @param {ConfigurationBase} config
+     * @augments ConfigurationStrategy
+     */
+    constructor(config) {
+        super(config);
+    }
+
+    /**
+     * @param {DataModel} model
+     * @returns {DataObjectConstructor}
+     */
+    // eslint-disable-next-line no-unused-vars
+    resolve(model) {
+        throw new AbstractMethodError();
+    }
+}
+
+class DefaultModelClassLoaderStrategy extends ModelClassLoaderStrategy {
+
+    constructor(config) {
+        super(config);
+    }
+
+    /**
+     * @param {*} model
+     * @returns {DataObjectConstructor}
+     */
+    resolve(model) {
+        Args.notNull(model, 'Model');
+        var dataObjectClassProperty = 'DataObjectClass';
+        // get data object class from the given model
+        var DataObjectClass = model.DataObjectClass;
+        // if DataObjectClass is a constructor
+        if (typeof DataObjectClass === 'function') {
+            return DataObjectClass;
+        }
+        // get model definition
+        var modelDefinition = this.getConfiguration().getStrategy(SchemaLoaderStrategy).getModelDefinition(model.name);
+        var executionPath = this.getConfiguration().getExecutionPath();
+        // noinspection ExceptionCaughtLocallyJS
+        if (typeof model.classPath === 'string') {
+            if (/^\.\//.test(model.classPath)) {
+                modelDefinition[dataObjectClassProperty] = DataObjectClass = interopRequireDefault(PathUtils.join(executionPath, model.classPath));
+            }
+            else {
+                modelDefinition[dataObjectClassProperty] = DataObjectClass = interopRequireDefault(model.classPath);
+            }
+        }
+        else {
+            var requireModules = [
+                // e.g. ./models/OrderDetail
+                PathUtils.join(executionPath, 'models', model.name),
+                // e.g. ./models/OrderDetailModel
+                PathUtils.join(executionPath,'models', model.name.concat('Model')),
+                // e.g. ./models/order-detail-model
+                PathUtils.join(executionPath,'models',_.dasherize(model.name).concat('-model')),
+                // e.g. ./models/order-detail.model
+                PathUtils.join(executionPath,'models',_.dasherize(model.name).concat('.model')),
+            ];
+            for (var requiredModule of requireModules) {
+                try {
+                    var module = require(requiredModule);
+                    // try to find if module has an exported member with name equal to this model name
+                    if (hasOwnProperty(module, model.name) && typeof module[model.name] === 'function') {
+                        modelDefinition[dataObjectClassProperty] = DataObjectClass = module[model.name];
+                    } else if (hasOwnProperty(module, '__esModule') && typeof module.default === 'function') {
+                        // try to find the default export
+                        modelDefinition[dataObjectClassProperty] = DataObjectClass = module.default;
+                    } else if (typeof module === 'function') {
+                        // otherwise validate module
+                        modelDefinition[dataObjectClassProperty] = DataObjectClass = module;
+                    }
+                    if (DataObjectClass != null) {
+                        return DataObjectClass;
+                    }
+                    // and throw error if module has an invalid format
+                    var error = Object.assign(new Error('Data model class module is invalid. Expected a class to be exported as default or named member'),
+                    {
+                        code: 'MODULE_INVALID',
+                        module: requiredModule
+                    });
+                    // noinspection ExceptionCaughtLocallyJS
+                    throw error;
+                } catch (err) {
+                    if (err.code !== 'MODULE_NOT_FOUND') {
+                        throw err;
+                    }
+                    // otherwise, continue
+                }
+            }
+            // check if model inherits another model and return its class
+            if (model.inherits != null) {
+                var inheritedModel = model.context.model(model.inherits);
+                if (inheritedModel == null) {
+                    throw new Error('Inherited model cannot be found');
+                }
+                modelDefinition[dataObjectClassProperty] = DataObjectClass = this.resolve(inheritedModel);
+            } else if (model.implements != null) {
+                var implementedModel = model.context.model(model.implements);
+                if (implementedModel == null) {
+                    throw new Error('Implemented model cannot be found');
+                }
+                modelDefinition[dataObjectClassProperty] = DataObjectClass = this.resolve(implementedModel);
+
+            } else {
+                // finally, return DataObject
+                modelDefinition[dataObjectClassProperty] = DataObjectClass = require('./data-object').DataObject;
+            }
+        }
+        return DataObjectClass;
+    }
+}
 
 /**
  * Gets the current data configuration
@@ -1098,7 +1078,7 @@ function createInstance() {
 
 /**
  * Gets an instance of DataConfiguration class based on the given name.
- * If the named data configuration does not exists, it will create a new instance of DataConfiguration class with the given name.
+ * If the named data configuration does not exist, it will create a new instance of DataConfiguration class with the given name.
  * @param {string} name - A string which represents the name of the data configuration
  * @returns {DataConfiguration}
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@babel/plugin-proposal-decorators": "^7.17.2",
         "@babel/preset-env": "^7.23.8",
         "@babel/preset-typescript": "^7.16.7",
-        "@themost/common": "^2.10.4",
+        "@themost/common": "^2.12.0",
         "@themost/json-logger": "^1.1.0",
         "@themost/peers": "^1.0.2",
         "@themost/query": "^2.6.77",
@@ -4130,20 +4130,25 @@
       }
     },
     "node_modules/@themost/common": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/@themost/common/-/common-2.10.4.tgz",
-      "integrity": "sha512-uR2qQfc/GbzgnNjaZ2HaGQ0QRCRMsIY6HdNyLTqWR3Oyg4BSfXzv7Yod/Y96KsjpV+6YAD0bCyc/kuFIGXY+WQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@themost/common/-/common-2.12.0.tgz",
+      "integrity": "sha512-yyTF5VHf13bTnIb6XU3/LOd4oxXRgtwr0X87sqHrNv2etY2jJ9agBOXbSu9zUkgFA2lAoAPo6S94gG02g/Qo7w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^2.6.4",
         "blueimp-md5": "^2.7.0",
+        "crypto-js": "^4.2.0",
         "es6-promise": "^4.2.8",
         "events": "^3.2.0",
         "hashmap": "^2.3.0",
         "lodash": "^4.17.21",
         "sprintf-js": "^1.1.2",
-        "symbol": "^0.3.1"
+        "symbol": "^0.3.1",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=12.22.12"
       }
     },
     "node_modules/@themost/events": {
@@ -14265,19 +14270,21 @@
       }
     },
     "@themost/common": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/@themost/common/-/common-2.10.4.tgz",
-      "integrity": "sha512-uR2qQfc/GbzgnNjaZ2HaGQ0QRCRMsIY6HdNyLTqWR3Oyg4BSfXzv7Yod/Y96KsjpV+6YAD0bCyc/kuFIGXY+WQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@themost/common/-/common-2.12.0.tgz",
+      "integrity": "sha512-yyTF5VHf13bTnIb6XU3/LOd4oxXRgtwr0X87sqHrNv2etY2jJ9agBOXbSu9zUkgFA2lAoAPo6S94gG02g/Qo7w==",
       "dev": true,
       "requires": {
         "async": "^2.6.4",
         "blueimp-md5": "^2.7.0",
+        "crypto-js": "^4.2.0",
         "es6-promise": "^4.2.8",
         "events": "^3.2.0",
         "hashmap": "^2.3.0",
         "lodash": "^4.17.21",
         "sprintf-js": "^1.1.2",
-        "symbol": "^0.3.1"
+        "symbol": "^0.3.1",
+        "uuid": "^10.0.0"
       }
     },
     "@themost/events": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.6.86",
+  "version": "2.6.87",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.6.86",
+      "version": "2.6.87",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@themost/xml": "^2.5.2"
   },
   "engines": {
-    "node": ">=8.17.0"
+    "node": ">=14.21.3"
   },
   "repository": {
     "type": "git",
@@ -45,7 +45,7 @@
     "@babel/plugin-proposal-decorators": "^7.17.2",
     "@babel/preset-env": "^7.23.8",
     "@babel/preset-typescript": "^7.16.7",
-    "@themost/common": "^2.10.4",
+    "@themost/common": "^2.12.0",
     "@themost/json-logger": "^1.1.0",
     "@themost/peers": "^1.0.2",
     "@themost/query": "^2.6.77",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.86",
+  "version": "2.6.87",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "types": "index.d.ts",

--- a/spec/DataApplication.spec.ts
+++ b/spec/DataApplication.spec.ts
@@ -1,4 +1,4 @@
-import {DataApplication} from '../data-application';
+import {DataApplication} from '@themost/data';
 import { ApplicationService, ApplicationBase } from '@themost/common';
 import {resolve} from 'path';
 import {TestUtils} from './adapter/TestUtils';
@@ -28,6 +28,19 @@ describe('DataApplication', () => {
     it('should create instance', async () => {
         const app = new DataApplication(cwd);
         expect(app).toBeTruthy();
+        await TestUtils.finalize(app);
+    });
+    it('should create an instance with configuration', async () => {
+        const app = new DataApplication({
+            settings: {
+                service1: {
+                    origin: 'https://api.example.com',
+                }
+            }
+        });
+        expect(app).toBeTruthy();
+        const origin = app.configuration.getSourceAt('settings/service1/origin');
+        expect(origin).toBe('https://api.example.com');
         await TestUtils.finalize(app);
     });
     it('should get configuration', async () => {


### PR DESCRIPTION
This PR converts data configuration classes to ES6 classes following changes implemented at `@themost/common@2.12.0` for `ConfigurationBase` parent class.