### PR TITLE
use json fields as object tags

### DIFF
--- a/OnJsonAttribute.js
+++ b/OnJsonAttribute.js
@@ -125,6 +125,8 @@ class OnJsonAttribute {
                 return include && attr.type === 'Json' && attr.additionalType != null && attr.model === event.model.name;
             }).filter((attr) => {
                 return Object.prototype.hasOwnProperty.call(event.target, attr.name);
+            }).filter((attr) => {
+                return !attr.many;
             });
             // exit if there are no json attributes
             if (attributes.length === 0) {
@@ -244,6 +246,8 @@ class OnJsonAttribute {
         try {
             const jsonAttributes = event.model.attributes.filter((attr) => {
                 return attr.type === 'Json' && attr.model === event.model.name;
+            }).filter((attr) => {
+                return !attr.many;
             }).map((attr) => attr.name);
             // try to find json attributes that are included in join expressions
             const joins = event.emitter && event.emitter.query && event.emitter.query.$expand;

--- a/data-attribute-resolver.js
+++ b/data-attribute-resolver.js
@@ -573,6 +573,24 @@ DataAttributeResolver.prototype.resolveJunctionAttributeJoin = function(attr) {
             q.join(entity).with(expr);
             //data object tagging
             if (typeof mapping.childModel === 'undefined') {
+                // check if field value
+                if (field.type === 'Json') {
+                    var objectPath = [
+                        associationAlias,
+                        mapping.associationValueField,
+                        ...member.slice(1)
+                    ].join('.');
+                    var objectGet = new MethodCallExpression('jsonGet', [
+                        new MemberExpression(objectPath)
+                    ]);
+                    return {
+                        $distinct,
+                        $select: new QueryField({
+                            $value: objectGet.exprOf()
+                        }),
+                        $expand: [q.$expand]
+                    }
+                }
                 return {
                     $distinct,
                     $expand:[q.$expand],

--- a/data-listeners.js
+++ b/data-listeners.js
@@ -104,13 +104,18 @@ UniqueConstraintListener.prototype.beforeSave = function(event, callback) {
             }
             //check field mapping
             var mapping = event.model.inferMapping(attr);
-            if (typeof mapping !== 'undefined' && mapping !== null) {
+            var attribute = event.model.getAttribute(attr);
+            if (mapping) {
                 if (typeof event.target[attr] === 'object') {
                     value=event.target[attr][mapping.parentField];
                 }
             }
-            if (typeof value=== 'undefined')
+            if (typeof value === 'undefined') {
                 value = null;
+            }
+            if (attribute.type === 'Json' && value != null) {
+                value = JSON.stringify(value);
+            }
             if (q) {
                 q.and(attr).equal(value);
             }

--- a/data-state-validator.js
+++ b/data-state-validator.js
@@ -3,6 +3,7 @@ var _ = require('lodash');
 var {DataNotFoundError} = require('@themost/common');
 var async = require('async');
 var {hasOwnProperty} = require('./has-own-property');
+var { isObjectDeep } = require('./is-object');
 /**
  * @class
  * @constructor
@@ -118,6 +119,11 @@ function mapKey_(obj, callback) {
                         }
                     }
                     else {
+                        // get attribute and check if type is JSON and value is object
+                        var attribute = self.getAttribute(attr);
+                        if (attribute && attribute.type === 'Json' && isObjectDeep(value)) {
+                            value = JSON.stringify(value);
+                        }
                         fnAppendQuery(attr, value);
                     }
                 }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,4 @@
+process.env.NODE_ENV = 'development';
 const {TraceUtils} = require('@themost/common');
 const JestLogger = require('./jest.logger');
 // noinspection JSCheckFunctionSignatures

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,4 +1,3 @@
-process.env.NODE_ENV = 'development';
 const {TraceUtils} = require('@themost/common');
 const JestLogger = require('./jest.logger');
 // noinspection JSCheckFunctionSignatures

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.19.1",
+  "version": "2.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.19.1",
+      "version": "2.19.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@themost/common": "^2.12.0",
         "@themost/peers": "^1.0.2",
         "@themost/query": "^2.14.7",
-        "@themost/sqlite": "^2.8.4",
+        "@themost/sqlite": "^2.10.1",
         "@themost/xml": "^2.5.2",
         "@types/core-js": "^2.5.0",
         "@types/crypto-js": "^4.2.2",
@@ -2834,9 +2834,10 @@
       }
     },
     "node_modules/@themost/events": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@themost/events/-/events-1.0.5.tgz",
-      "integrity": "sha512-4G5OcgMXL0z7MdMLvxdvGnt5oXFKOwH3Bv1U4Mn39raO+oRXzT3oF7uip/nRtbXEQLyLgwfyKlOCU97656YLHg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@themost/events/-/events-1.5.0.tgz",
+      "integrity": "sha512-R+q764cVNDPW4CYKr6Le1LCty1YYieKHbh9mJwv3gDo9fG2wtoN23T85ABnsQpTOkkJOsxk0+Tl3tPM3dblEjQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@themost/peers": {
       "version": "1.0.2",
@@ -2875,13 +2876,16 @@
       "dev": true
     },
     "node_modules/@themost/sqlite": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/@themost/sqlite/-/sqlite-2.8.4.tgz",
-      "integrity": "sha512-pmkf18CUqnJ1dqZwVdCZtS9LU9xsgVvKitjuTh9xX0Ym2L02iBTPWcPx7uemZCwUOaXi9cw5mikdpi2pPsMIlA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@themost/sqlite/-/sqlite-2.10.1.tgz",
+      "integrity": "sha512-GZmpEwnfuwoh2xijxmyCRWofb7v67EGfiD88BsWsCW18KE560Uvt0k3Az9Pzne+TPcB0KNoUYvtPRTKwJXjDxQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
+        "@themost/events": "^1.5.0",
         "async": "^2.6.4",
+        "lodash": "^4.17.21",
         "sprintf-js": "^1.1.2",
         "sqlite3": "^5.1.7",
         "unzipper": "^0.12.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.19.1",
+  "version": "2.19.2",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@themost/common": "^2.12.0",
     "@themost/peers": "^1.0.2",
     "@themost/query": "^2.14.7",
-    "@themost/sqlite": "^2.8.4",
+    "@themost/sqlite": "^2.10.1",
     "@themost/xml": "^2.5.2",
     "@types/core-js": "^2.5.0",
     "@types/crypto-js": "^4.2.2",

--- a/spec/DataObjectTag.spec.ts
+++ b/spec/DataObjectTag.spec.ts
@@ -217,4 +217,35 @@ describe('DataObjectTag', () => {
 
     });
 
+    it('should try to select json object attributes', async () => {
+        const PeopleAudience = context.model('PeopleAudience').silent();
+        const newAudience = {
+            name: 'Top customers',
+            preferredName: [
+                { recordLanguage: 'en',  value: 'Top customers' },
+                { recordLanguage: 'fr',  value: 'Meilleurs clients' }
+            ]
+        };
+        await PeopleAudience.save(newAudience);
+        let audience = await PeopleAudience
+            .asQueryable().where((x: { preferredName: { value: string } }) => {
+                return x.preferredName.value === 'Meilleurs clients';
+            }).select((x: any) => {
+                return {
+                    id: x.id,
+                    preferredName: x.preferredName.value
+                }
+            }).getItem();
+        expect(audience).toBeTruthy();
+        expect(audience.preferredName).toEqual('Meilleurs clients');
+        audience = await PeopleAudience
+            .where('preferredName/value')
+            .equal('Meilleurs clients')
+            .select('id', 'preferredName/value as preferredName')
+            .getItem();
+        expect(audience).toBeTruthy();
+        expect(audience.preferredName).toEqual('Meilleurs clients');
+
+    });
+
 });

--- a/spec/DataObjectTag.spec.ts
+++ b/spec/DataObjectTag.spec.ts
@@ -211,7 +211,7 @@ describe('DataObjectTag', () => {
         audience = await PeopleAudience
             .where((x: { preferredName: { value: string } }) => {
                 return x.preferredName.value === 'Meilleurs clients';
-            }).equal('Meilleurs clients')
+            })
             .getTypedItem();
         expect(audience).toBeTruthy();
 

--- a/spec/DataObjectTag.spec.ts
+++ b/spec/DataObjectTag.spec.ts
@@ -187,4 +187,34 @@ describe('DataObjectTag', () => {
         });
     });
 
+    it('should try to insert json objects', async () => {
+        const PeopleAudience = context.model('PeopleAudience').silent();
+        const newAudience = {
+            name: 'Top customers',
+            preferredName: [
+                { recordLanguage: 'en',  value: 'Top customers' },
+                { recordLanguage: 'fr',  value: 'Meilleurs clients' }
+            ]
+        };
+        await PeopleAudience.save(newAudience)
+        let audience = await PeopleAudience
+            .where((x: { name: string })=> {
+                return x.name === 'Top customers';
+            })
+            .expand((x: { preferredName: unknown }) => x.preferredName)
+            .getTypedItem();
+        expect(audience).toBeTruthy();
+        expect(Array.isArray(audience.preferredName)).toBeTruthy();
+        const preferredName = audience.preferredName.find((x) => x.recordLanguage === 'en');
+        expect(preferredName).toBeTruthy();
+
+        audience = await PeopleAudience
+            .where((x: { preferredName: { value: string } }) => {
+                return x.preferredName.value === 'Meilleurs clients';
+            }).equal('Meilleurs clients')
+            .getTypedItem();
+        expect(audience).toBeTruthy();
+
+    });
+
 });

--- a/spec/TestApplication.ts
+++ b/spec/TestApplication.ts
@@ -4,16 +4,15 @@ import {
     DataConfigurationStrategy,
     NamedDataContext,
     DataContext,
-    DataApplication,
     DataCacheStrategy,
-    DataCacheFinalize
+    DataCacheFinalize, DataAdapterTypeConfiguration
 } from '../index';
 import fs from 'fs';
 
 export class TestApplication extends IApplication {
 
     private _services: Map<any,any> = new Map();
-    private _configuration: ConfigurationBase;
+    private readonly _configuration: ConfigurationBase;
 
     useStrategy(serviceCtor: void, strategyCtor: void): this {
         const ServiceClass: any = serviceCtor;
@@ -60,8 +59,8 @@ export class TestApplication extends IApplication {
     }
 
     createContext(): DataContext {
-        const adapters = this._configuration.getSourceAt('adapters');
-        const adapter: { name: string; invariantName: string; default: boolean } = adapters.find((item: any)=> {
+        const adapters: DataAdapterTypeConfiguration[] = this._configuration.getSourceAt('adapters') as DataAdapterTypeConfiguration[];
+        const adapter: DataAdapterTypeConfiguration = adapters.find((item: any)=> {
             return item.default;
         });
         const context = new NamedDataContext(adapter.name);
@@ -72,6 +71,7 @@ export class TestApplication extends IApplication {
     }
 
     async finalize(): Promise<void> {
+        // @ts-ignore
         const service = this.getConfiguration().getStrategy(DataCacheStrategy) as unknown as DataCacheFinalize;
         if (typeof service.finalize === 'function') {
             await service.finalize();
@@ -89,7 +89,9 @@ export class TestApplication2 extends TestApplication {
         const source = resolve(__dirname, 'test2/db', 'local.db');
         const dest = resolve(__dirname, 'test2/db', 'test.db');
         fs.copyFileSync(source, dest);
-        this.getConfiguration().getSourceAt('adapters').unshift({
+        // noinspection JSMismatchedCollectionQueryUpdate
+        const adapters: unknown[] = this.getConfiguration().getSourceAt('adapters') as unknown[];
+        adapters.unshift({
             name: 'test-local',
             invariantName: 'test',
             default: true,

--- a/spec/adapter/TestUtils.ts
+++ b/spec/adapter/TestUtils.ts
@@ -1,8 +1,8 @@
 /**
  * @description An error for cancelling transaction in testing environments
  */
-import {DataApplication} from '../../data-application';
-import {DataCacheFinalize, DataCacheStrategy} from '../../data-cache';
+import {DataApplication} from '@themost/data';
+import {DataCacheFinalize, DataCacheStrategy} from '@themost/data';
 
 export class CancelTransactionError extends Error {
     constructor() {
@@ -58,6 +58,7 @@ export class TestUtils {
         if (app == null) {
             return;
         }
+        // @ts-ignore
         const service = app.getConfiguration().getStrategy(DataCacheStrategy) as unknown as DataCacheFinalize;
         if (typeof service.finalize === 'function') {
             await service.finalize();

--- a/spec/test2/config/models/Audience.json
+++ b/spec/test2/config/models/Audience.json
@@ -10,6 +10,14 @@
   "version": "1.0",
   "fields": [
     {
+      "@id": "https://themost.io/schemas/id",
+      "name": "id",
+      "title": "ID",
+      "description": "The identifier of the item.",
+      "type": "Counter",
+      "primary": true
+    },
+    {
       "name": "audienceType",
       "title": "Audience Type",
       "description": "The target group associated with a given audience (e.g. veterans, car owners, musicians, etc.).",

--- a/spec/test2/config/models/LanguageTypedString.json
+++ b/spec/test2/config/models/LanguageTypedString.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://themost-framework.github.io/themost/models/2018/2/schema.json",
+  "caching": "conditional",
+  "hidden": true,
+  "name": "LanguageTypedString",
+  "title": "LanguageTypedString",
+  "description": "A String with an associated language code.",
+  "version": "1.0.0",
+  "fields": [
+    {
+      "@id": "urn:themost:framework:schemas:recordLanguage",
+      "name": "recordLanguage",
+      "description": "The primary language used in the described entity.",
+      "type": "Text",
+      "nullable": false,
+      "many": false,
+      "size": 5
+    },
+    {
+      "@id": "urn:themost:framework:schemas:value",
+      "name": "value",
+      "description": "No description supplied.",
+      "type": "Text",
+      "nullable": false,
+      "many": false
+    }
+  ],
+  "constraints": [],
+  "eventListeners": [],
+  "privileges": [
+    {
+      "type": "global",
+      "mask": 15
+    },
+    {
+      "type": "global",
+      "mask": 15,
+      "account": "Administrators"
+    }
+  ]
+}

--- a/spec/test2/config/models/PeopleAudience.json
+++ b/spec/test2/config/models/PeopleAudience.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://themost-framework.github.io/themost/models/2018/2/schema.json",
+  "@id": "https://schema.org/PeopleAudience",
+  "name": "PeopleAudience",
+  "description": "An audience defined by a particular demographic.",
+  "title": "PeopleAudience",
+  "abstract": false,
+  "sealed": false,
+  "inherits": "Audience",
+  "version": "1.0.0",
+  "fields": [
+    {
+      "name": "id",
+      "title": "Id",
+      "type": "Integer",
+      "nullable": false,
+      "primary": true
+    },
+    {
+      "name": "preferredName",
+      "title": "Preferred Name",
+      "type": "Json",
+      "description": "The name preferred by the audience.",
+      "many": true,
+      "additionalType": "LanguageTypedString",
+      "mapping": {
+        "associationType": "junction",
+        "associationObjectField": "audience",
+        "associationValueField": "languageString"
+      }
+    }
+  ],
+  "privileges": [
+    {
+      "mask": 15,
+      "type": "global"
+    },
+    {
+      "mask": 15,
+      "type": "global",
+      "account": "Administrators"
+    }
+  ]
+}


### PR DESCRIPTION
This PR updates object tags -a collection of primitive typed values associated with an object- to support JSON type values. This feature integrates data object tagging specification and allows the usage of complex types alongside with primitive types.

The following example

```json
{
      "name": "preferredName",
      "title": "Preferred Name",
      "type": "Json",
      "description": "The name preferred by the audience.",
      "many": true,
      "additionalType": "LanguageTypedString",
      "mapping": {
        "associationType": "junction",
        "associationObjectField": "audience",
        "associationValueField": "languageString"
      }
}
```

describes `preferredName` field which uses a JSON object of type `LanguageTypedString`. This model might be defined using the following schema:

```json
{
  "$schema": "https://themost-framework.github.io/themost/models/2018/2/schema.json",
  "caching": "conditional",
  "hidden": true,
  "name": "LanguageTypedString",
  "title": "LanguageTypedString",
  "description": "A String with an associated language code.",
  "version": "1.0.0",
  "fields": [
    {
      "@id": "urn:themost:framework:schemas:recordLanguage",
      "name": "recordLanguage",
      "description": "The primary language used in the described entity.",
      "type": "Text",
      "nullable": false,
      "many": false,
      "size": 5
    },
    {
      "@id": "urn:themost:framework:schemas:value",
      "name": "value",
      "description": "No description supplied.",
      "type": "Text",
      "nullable": false,
      "many": false
    }
  ]
}
```

where `LanguageTypedString` is a collection of objects with `recordLanguage` and `value` attributes.


