### PR TITLE
[LTS] Validate json type attributes

### DIFF
--- a/data-model.js
+++ b/data-model.js
@@ -1574,6 +1574,8 @@ function castForValidation_(obj, state) {
                     else
                     //set raw value
                         result[x.name] = obj[name];
+                } else if (mapping.associationType==='junction') {
+                    result[x.name] = obj[name];
                 }
             }
         });
@@ -2895,6 +2897,10 @@ function validate_(obj, state, callback) {
         //-- DataTypeValidator #2
         if (attr.type && hasOwnProperty(objCopy, attr.name)) {
             arrValidators.push(new validators.DataTypeValidator(attr.type));
+        }
+        // Validate JSON typed attributes
+        if (attr.type === 'Json' && attr.additionalType != null) {
+            arrValidators.push(new validators.JsonTypeValidator(attr.additionalType, state));
         }
 
         if (arrValidators.length === 0) {

--- a/data-validator.d.ts
+++ b/data-validator.d.ts
@@ -8,7 +8,7 @@ export declare interface DataValidationResult {
 }
 
 export declare class DataValidator {
-    setContext(context: DataContext);
+    setContext(context: DataContext): void;
     getContext(): DataContext;
     target: any;
 }
@@ -68,6 +68,11 @@ export declare class DataTypeValidator extends DataValidator {
 export declare class RequiredValidator extends DataValidator {
     constructor();
     validateSync(val:any): DataValidationResult;
+}
+
+export declare class JsonTypeValidator extends DataValidator {
+    constructor(type: string, state: number);
+    validate(value: unknown, callback?: (err?: Error, res?: DataValidationResult) => void): void;
 }
 
 export declare class DataValidatorListener implements  BeforeSaveEventListener {

--- a/data-validator.js
+++ b/data-validator.js
@@ -1045,6 +1045,12 @@ var {hasOwnProperty} = require('./has-own-property');
         else if ((typeof val === 'number') && isNaN(val)) {
             invalid=true;
         }
+        // validate array
+        if (Array.isArray(val)) {
+            if (val.length===0) {
+                invalid=true;
+            }
+        }
         if (invalid) {
 
             var innerMessage = null, message = 'A value is required.';
@@ -1062,6 +1068,76 @@ var {hasOwnProperty} = require('./has-own-property');
         }
     };
 
+    /**
+     *
+     * @param {string} additionalType
+     * @param {number} state
+     * @constructor
+     */
+    function JsonTypeValidator(additionalType, state) {
+        // noinspection JSUnresolvedReference
+        JsonTypeValidator.super_.call(this);
+        this.state = state;
+        this.additionalType = additionalType;
+    }
+    LangUtils.inherits(JsonTypeValidator, DataValidator);
+    /**
+     *
+     * @param {*} val
+     * @param {function(err?: *, validationResult?: *): void} callback
+     * @returns {void}
+     */
+    JsonTypeValidator.prototype.validate = function(val, callback) {
+        if (this.additionalType != null) {
+            // noinspection ES6ConvertVarToLetConst
+            /**
+             * @type {DataContext}
+             */
+            var context = this.getContext();
+            // noinspection ES6ConvertVarToLetConst
+            var additionalModel = context.model(this.additionalType);
+            if (additionalModel == null) {
+                return callback(null, {
+                    code:'E_MODEL',
+                    message: sprintf('The additional model "%s" for Json type cannot be found.', this.additionalType)
+                });
+            }
+            const values = Array.isArray(val) ? val : [val];
+            const state = this.state;
+
+            (async function() {
+                // noinspection ES6ConvertVarToLetConst
+                var res;
+                // noinspection ES6ConvertVarToLetConst
+                var attributes = additionalModel.attributeNames;
+                for (const value of values) {
+                    if (value != null) {
+                        const keys = Object.keys(value);
+                        const unknownKeys = keys.filter(function(k) {
+                            return attributes.indexOf(k) < 0;
+                        });
+                        if (unknownKeys.length > 0) {
+                            return {
+                                code:'E_UNKNOWN',
+                                message: sprintf('The target model "%s" does not contain attribute(s) %s.', additionalModel.name, unknownKeys.map(function(k) { return "\"" + k + "\"" }).slice(0, 5).join(', '))
+                            };
+                        }
+                    }
+                    if (state === 1) {
+                       res = await additionalModel.validateForInsert(value);
+                       if (res) return res;
+                    } else if (state === 2) {
+                       res = await additionalModel.validateForUpdate(value);
+                       if (res) return res;
+                    }
+                }
+            })().then(function(result) {
+                return callback(null, result);
+            }).catch(function(err) {
+                return callback(err);
+            });
+        }
+    };
 
     module.exports = {
         PatternValidator,
@@ -1073,7 +1149,8 @@ var {hasOwnProperty} = require('./has-own-property');
         RangeValidator,
         RequiredValidator,
         DataTypeValidator,
-        DataValidatorListener
+        DataValidatorListener,
+        JsonTypeValidator
     };
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.6.88",
+  "version": "2.6.89",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.6.88",
+      "version": "2.6.89",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.6.88",
+  "version": "2.6.89",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This PR upgrades item validation to include json type attributes that have an additional type defined. This operation validates JSON objects against rules defined by the additional model e.g. a required value or a pattern validation etc. It also validates that the target object does not contain attributes that don't exist in target model. 