### PR TITLE
fix: implement `EdmFilter.func` decorator to map methods as valid OData expressions

### DIFF
--- a/data-filter-resolver.d.ts
+++ b/data-filter-resolver.d.ts
@@ -9,3 +9,7 @@ export declare class DataFilterResolver {
     lang(callback: (err?: Error, res?: string) => void);
 
 }
+
+export class EdmFilter {
+    static expression(): Function;
+}

--- a/data-filter-resolver.d.ts
+++ b/data-filter-resolver.d.ts
@@ -11,5 +11,5 @@ export declare class DataFilterResolver {
 }
 
 export class EdmFilter {
-    static expression(): Function;
+    static func(): Function;
 }

--- a/data-filter-resolver.js
+++ b/data-filter-resolver.js
@@ -107,7 +107,7 @@ function EdmFilter() {
  * Maps a method as a valid OData filter function
  * @returns {Function}
  */
-EdmFilter.expression = function() {
+EdmFilter.func = function() {
     return function(target, key, descriptor) {
         if (typeof descriptor.value !== 'function') {
             throw new Error('Decorator is not valid on this declaration type.');
@@ -117,11 +117,11 @@ EdmFilter.expression = function() {
     };
 };
 
-defineDecorator(DataFilterResolver.prototype, 'me', EdmFilter.expression());
-defineDecorator(DataFilterResolver.prototype, 'now', EdmFilter.expression());
-defineDecorator(DataFilterResolver.prototype, 'today', EdmFilter.expression());
-defineDecorator(DataFilterResolver.prototype, 'lang', EdmFilter.expression());
-defineDecorator(DataFilterResolver.prototype, 'user', EdmFilter.expression());
+defineDecorator(DataFilterResolver.prototype, 'me', EdmFilter.func());
+defineDecorator(DataFilterResolver.prototype, 'now', EdmFilter.func());
+defineDecorator(DataFilterResolver.prototype, 'today', EdmFilter.func());
+defineDecorator(DataFilterResolver.prototype, 'lang', EdmFilter.func());
+defineDecorator(DataFilterResolver.prototype, 'user', EdmFilter.func());
 
 module.exports = {
     DataFilterResolver,

--- a/data-filter-resolver.js
+++ b/data-filter-resolver.js
@@ -37,7 +37,10 @@ DataFilterResolver.prototype.resolveMember = function(member, callback) {
 DataFilterResolver.prototype.resolveMethod = function(name, args, callback) {
     callback = callback || function() { };
     var fn = DataFilterResolver.prototype[name];
-    if (typeof fn === 'function' && fn.filterDecorator === true) {
+    if (typeof fn === 'function') {
+        if (fn.filterDecorator !== true) {
+            return callback(new Error('The specified method has not been marked as a filter method.'));
+        }
         var a = args || [];
         a.push(callback);
         try {

--- a/data-filter-resolver.js
+++ b/data-filter-resolver.js
@@ -3,7 +3,7 @@
 // noinspection ES6ConvertVarToLetConst
 
 var {FunctionContext} = require('./functions');
-var {EdmMapping} = require('./odata');
+var {defineDecorator} = require('./odata');
 
 /**
  * @module @themost/data/data-filter-resolver
@@ -94,12 +94,36 @@ DataFilterResolver.prototype.user = function(callback) {
     return this.me(callback);
 };
 
-Object.defineDecorator(DataFilterResolver.prototype, 'me', EdmMapping.filter);
-Object.defineDecorator(DataFilterResolver.prototype, 'now', EdmMapping.filter);
-Object.defineDecorator(DataFilterResolver.prototype, 'today', EdmMapping.filter);
-Object.defineDecorator(DataFilterResolver.prototype, 'lang', EdmMapping.filter);
-Object.defineDecorator(DataFilterResolver.prototype, 'user', EdmMapping.filter);
+/**
+ * @class
+ * @constructor
+ */
+function EdmFilter() {
+    //
+}
+
+/**
+ * @static
+ * Maps a method as a valid OData filter function
+ * @returns {Function}
+ */
+EdmFilter.expression = function() {
+    return function(target, key, descriptor) {
+        if (typeof descriptor.value !== 'function') {
+            throw new Error('Decorator is not valid on this declaration type.');
+        }
+        descriptor.value.filterDecorator = true;
+        return descriptor;
+    };
+};
+
+defineDecorator(DataFilterResolver.prototype, 'me', EdmFilter.expression);
+defineDecorator(DataFilterResolver.prototype, 'now', EdmFilter.expression);
+defineDecorator(DataFilterResolver.prototype, 'today', EdmFilter.expression);
+defineDecorator(DataFilterResolver.prototype, 'lang', EdmFilter.expression);
+defineDecorator(DataFilterResolver.prototype, 'user', EdmFilter.expression);
 
 module.exports = {
-    DataFilterResolver
+    DataFilterResolver,
+    EdmFilter,
 };

--- a/data-filter-resolver.js
+++ b/data-filter-resolver.js
@@ -35,7 +35,7 @@ DataFilterResolver.prototype.resolveMember = function(member, callback) {
 
 DataFilterResolver.prototype.resolveMethod = function(name, args, callback) {
     callback = callback || function() { };
-    if (typeof DataFilterResolver.prototype[name] === 'function') {
+    if (Object.prototype.hasOwnProperty.call(DataFilterResolver.prototype, name) && typeof DataFilterResolver.prototype[name] === 'function') {
         var a = args || [];
         a.push(callback);
         try {

--- a/data-filter-resolver.js
+++ b/data-filter-resolver.js
@@ -36,7 +36,7 @@ DataFilterResolver.prototype.resolveMember = function(member, callback) {
 
 DataFilterResolver.prototype.resolveMethod = function(name, args, callback) {
     callback = callback || function() { };
-    var fn = this[name];
+    var fn = typeof this[name] === 'function' ? this[name] : DataFilterResolver.prototype[name];
     if (typeof fn === 'function') {
         if (fn.filterDecorator !== true) {
             return callback(new Error('The specified method has not been marked as a filter method.'));

--- a/data-filter-resolver.js
+++ b/data-filter-resolver.js
@@ -35,16 +35,16 @@ DataFilterResolver.prototype.resolveMember = function(member, callback) {
 
 DataFilterResolver.prototype.resolveMethod = function(name, args, callback) {
     callback = callback || function() { };
-    if (Object.prototype.hasOwnProperty.call(DataFilterResolver.prototype, name) && typeof DataFilterResolver.prototype[name] === 'function') {
+    var fn = DataFilterResolver.prototype[name];
+    if (typeof fn === 'function' && fn.filterDecorator === true) {
         var a = args || [];
         a.push(callback);
         try {
-            return DataFilterResolver.prototype[name].apply(this, a);
+            return fn.apply(this, a);
         }
         catch(e) {
             return callback(e);
         }
-
     }
     callback();
 };
@@ -92,6 +92,22 @@ DataFilterResolver.prototype.lang = function(callback) {
 DataFilterResolver.prototype.user = function(callback) {
     return this.me(callback);
 };
+
+Object.defineDecorator(DataFilterResolver.prototype, 'me', function(target, key, descriptor) {
+    descriptor.value.filterDecorator = true;
+});
+Object.defineDecorator(DataFilterResolver.prototype, 'now', function(target, key, descriptor) {
+    descriptor.value.filterDecorator = true;
+});
+Object.defineDecorator(DataFilterResolver.prototype, 'today', function(target, key, descriptor) {
+    descriptor.value.filterDecorator = true;
+});
+Object.defineDecorator(DataFilterResolver.prototype, 'lang', function(target, key, descriptor) {
+    descriptor.value.filterDecorator = true;
+});
+Object.defineDecorator(DataFilterResolver.prototype, 'user', function(target, key, descriptor) {
+    descriptor.value.filterDecorator = true;
+});
 
 module.exports = {
     DataFilterResolver

--- a/data-filter-resolver.js
+++ b/data-filter-resolver.js
@@ -36,7 +36,7 @@ DataFilterResolver.prototype.resolveMember = function(member, callback) {
 
 DataFilterResolver.prototype.resolveMethod = function(name, args, callback) {
     callback = callback || function() { };
-    var fn = DataFilterResolver.prototype[name];
+    var fn = this[name];
     if (typeof fn === 'function') {
         if (fn.filterDecorator !== true) {
             return callback(new Error('The specified method has not been marked as a filter method.'));

--- a/data-filter-resolver.js
+++ b/data-filter-resolver.js
@@ -3,6 +3,7 @@
 // noinspection ES6ConvertVarToLetConst
 
 var {FunctionContext} = require('./functions');
+var {EdmMapping} = require('./odata');
 
 /**
  * @module @themost/data/data-filter-resolver
@@ -93,21 +94,11 @@ DataFilterResolver.prototype.user = function(callback) {
     return this.me(callback);
 };
 
-Object.defineDecorator(DataFilterResolver.prototype, 'me', function(target, key, descriptor) {
-    descriptor.value.filterDecorator = true;
-});
-Object.defineDecorator(DataFilterResolver.prototype, 'now', function(target, key, descriptor) {
-    descriptor.value.filterDecorator = true;
-});
-Object.defineDecorator(DataFilterResolver.prototype, 'today', function(target, key, descriptor) {
-    descriptor.value.filterDecorator = true;
-});
-Object.defineDecorator(DataFilterResolver.prototype, 'lang', function(target, key, descriptor) {
-    descriptor.value.filterDecorator = true;
-});
-Object.defineDecorator(DataFilterResolver.prototype, 'user', function(target, key, descriptor) {
-    descriptor.value.filterDecorator = true;
-});
+Object.defineDecorator(DataFilterResolver.prototype, 'me', EdmMapping.filter);
+Object.defineDecorator(DataFilterResolver.prototype, 'now', EdmMapping.filter);
+Object.defineDecorator(DataFilterResolver.prototype, 'today', EdmMapping.filter);
+Object.defineDecorator(DataFilterResolver.prototype, 'lang', EdmMapping.filter);
+Object.defineDecorator(DataFilterResolver.prototype, 'user', EdmMapping.filter);
 
 module.exports = {
     DataFilterResolver

--- a/data-filter-resolver.js
+++ b/data-filter-resolver.js
@@ -3,7 +3,7 @@
 // noinspection ES6ConvertVarToLetConst
 
 var {FunctionContext} = require('./functions');
-var {defineDecorator} = require('./odata');
+var {defineDecorator} = require('./define-decorator');
 
 /**
  * @module @themost/data/data-filter-resolver
@@ -117,11 +117,11 @@ EdmFilter.expression = function() {
     };
 };
 
-defineDecorator(DataFilterResolver.prototype, 'me', EdmFilter.expression);
-defineDecorator(DataFilterResolver.prototype, 'now', EdmFilter.expression);
-defineDecorator(DataFilterResolver.prototype, 'today', EdmFilter.expression);
-defineDecorator(DataFilterResolver.prototype, 'lang', EdmFilter.expression);
-defineDecorator(DataFilterResolver.prototype, 'user', EdmFilter.expression);
+defineDecorator(DataFilterResolver.prototype, 'me', EdmFilter.expression());
+defineDecorator(DataFilterResolver.prototype, 'now', EdmFilter.expression());
+defineDecorator(DataFilterResolver.prototype, 'today', EdmFilter.expression());
+defineDecorator(DataFilterResolver.prototype, 'lang', EdmFilter.expression());
+defineDecorator(DataFilterResolver.prototype, 'user', EdmFilter.expression());
 
 module.exports = {
     DataFilterResolver,

--- a/define-decorator.d.ts
+++ b/define-decorator.d.ts
@@ -1,0 +1,1 @@
+export declare function defineDecorator(proto: Object|Function, key: string, decorator:Function): void;

--- a/define-decorator.js
+++ b/define-decorator.js
@@ -1,0 +1,35 @@
+/**
+ *
+ * @param {Object|Function} proto - The constructor function of a class or the prototype of a class
+ * @param {string} key - The name of the property or method where the decorator will be included
+ * @param {Function} decorator - The decorator to be included
+ */
+function defineDecorator(proto, key, decorator) {
+    if ((typeof proto !== 'object') && (typeof proto !== 'function')) {
+        throw new TypeError('Invalid prototype. Expected object or function.');
+    }
+    if (typeof key !== 'string') {
+        throw new TypeError('Invalid property name. Expected string or function.');
+    }
+    if (typeof decorator !== 'function') {
+        throw new TypeError('Invalid decorator. Expected function.');
+    }
+    decorator(proto, key, Object.getOwnPropertyDescriptor(proto, key));
+}
+
+//extend object
+if (typeof Object.defineDecorator === 'undefined') {
+    /**
+     * @function defineDecorator
+     * @param {Object|Function} proto - The constructor function of a class or the prototype of a class
+     * @param {string} key - The name of the property or method where the decorator will be included
+     * @param {Function} decorator - The decorator to be included
+     * @memberOf Object
+     * @static
+     */
+    Object.defineDecorator = defineDecorator;
+}
+
+module.exports = {
+  defineDecorator
+};

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 // MOST Web Framework 2.0 Codename Blueshift BSD-3-Clause license Copyright (c) 2017-2022, THEMOST LP All rights reserved
 export * from './data-configuration';
 export * from './types';
+export * from './define-decorator';
 export * from './data-model';
 export * from './data-queryable';
 export * from './data-object';

--- a/index.js
+++ b/index.js
@@ -65,7 +65,10 @@ var {
 var { PermissionMask,
     DataPermissionEventArgs,
     DataPermissionEventListener} = require('./data-permission');
-var { DataFilterResolver } = require('./data-filter-resolver');
+var {
+    DataFilterResolver,
+    EdmFilter,
+} = require('./data-filter-resolver');
 var { DataObjectJunction } = require('./data-object-junction');
 var { DataObjectTag } = require('./data-object-tag');
 var { HasOneAssociation } = require('./has-one-association');
@@ -169,6 +172,7 @@ module.exports = {
     ProcedureConfiguration,
     EdmType,
     EdmMapping,
+    EdmFilter,
     EdmMultiplicity,
     EntityCollectionConfiguration,
     EntityDataContext,

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ var {
     DataModelEventListener,
     DataModelPrivilege
 } = require('./types');
+var { defineDecorator } = require('./define-decorator');
 var { DataModel } = require('./data-model');
 var { DataQueryable } = require('./data-queryable');
 var { DataObject } = require('./data-object');
@@ -53,7 +54,6 @@ var {
     ProcedureConfiguration,
     EdmType,
     EdmMapping,
-    defineDecorator,
     EdmMultiplicity,
     EntityCollectionConfiguration,
     EntityDataContext,
@@ -119,6 +119,7 @@ module.exports = {
     ModelClassLoaderStrategy,
     SchemaLoaderStrategy,
     FileSchemaLoaderStrategy,
+    defineDecorator,
     DataModel,
     DataQueryable,
     DataObject,
@@ -168,7 +169,6 @@ module.exports = {
     ProcedureConfiguration,
     EdmType,
     EdmMapping,
-    defineDecorator,
     EdmMultiplicity,
     EntityCollectionConfiguration,
     EntityDataContext,

--- a/odata.d.ts
+++ b/odata.d.ts
@@ -55,6 +55,7 @@ export declare class EntitySetKind {
 
 export class EdmMapping {
     static entityType(name?: string): Function;
+    static filter(): Function;
     static action(name: string, returnType: any): Function;
     static func(name: string, returnType: any): Function;
     static param(name: string, type: string, nullable?: boolean, fromBody?: boolean): Function;

--- a/odata.d.ts
+++ b/odata.d.ts
@@ -55,7 +55,6 @@ export declare class EntitySetKind {
 
 export class EdmMapping {
     static entityType(name?: string): Function;
-    static filter(): Function;
     static action(name: string, returnType: any): Function;
     static func(name: string, returnType: any): Function;
     static param(name: string, type: string, nullable?: boolean, fromBody?: boolean): Function;

--- a/odata.d.ts
+++ b/odata.d.ts
@@ -213,5 +213,3 @@ export declare class EntityDataContext extends DataContext {
 export declare class ODataConventionModelBuilder extends ODataModelBuilder{
 
 }
-
-export declare function defineDecorator(proto: Object|Function, key: string, decorator:Function): void;

--- a/odata.js
+++ b/odata.js
@@ -2149,21 +2149,6 @@ EdmMapping.entityType = function (name) {
 
 /**
  * @static
- * Maps a method as a valid OData filter function
- * @returns {Function}
- */
-EdmMapping.filter = function() {
-    return function(target, key, descriptor) {
-        if (typeof descriptor.value !== 'function') {
-            throw new Error('Decorator is not valid on this declaration type.');
-        }
-        descriptor.value.filterDecorator = true;
-        return descriptor;
-    };
-};
-
-/**
- * @static
  * Maps a function to an OData entity type action
  * @param {string} name
  * @param {*=} returnType

--- a/odata.js
+++ b/odata.js
@@ -2149,6 +2149,21 @@ EdmMapping.entityType = function (name) {
 
 /**
  * @static
+ * Maps a method as a valid OData filter function
+ * @returns {Function}
+ */
+EdmMapping.filter = function() {
+    return function(target, key, descriptor) {
+        if (typeof descriptor.value !== 'function') {
+            throw new Error('Decorator is not valid on this declaration type.');
+        }
+        descriptor.value.filterDecorator = true;
+        return descriptor;
+    };
+};
+
+/**
+ * @static
  * Maps a function to an OData entity type action
  * @param {string} name
  * @param {*=} returnType

--- a/odata.js
+++ b/odata.js
@@ -2087,40 +2087,6 @@ ODataConventionModelBuilder.prototype.getEdmSync = function() {
 };
 
 
-
-
-
-/**
- *
- * @param {Object|Function} proto - The constructor function of a class or the prototype of a class
- * @param {string} key - The name of the property or method where the decorator will be included
- * @param {Function} decorator - The decorator to be included
- */
-function defineDecorator(proto, key, decorator) {
-    if ((typeof proto !== 'object') && (typeof proto !== 'function')) {
-        throw new TypeError('Invalid prototype. Expected object or function.');
-    }
-    if (typeof key !== 'string') {
-        throw new TypeError('Invalid property name. Expected string or function.');
-    }
-    if (typeof decorator !== 'function') {
-        throw new TypeError('Invalid decorator. Expected function.');
-    }
-    decorator(proto, key, Object.getOwnPropertyDescriptor(proto, key));
-}
-//extend object
-if (typeof Object.defineDecorator === 'undefined') {
-    /**
-     * @function defineDecorator
-     * @param {Object|Function} proto - The constructor function of a class or the prototype of a class
-     * @param {string} key - The name of the property or method where the decorator will be included
-     * @param {Function} decorator - The decorator to be included
-     * @memberOf Object
-     * @static
-     */
-    Object.defineDecorator = defineDecorator;
-}
-
 /**
  * @class
  * @constructor
@@ -2446,7 +2412,6 @@ module.exports = {
     SingletonConfiguration,
     ODataModelBuilder,
     ODataConventionModelBuilder,
-    EdmMapping,
-    defineDecorator
+    EdmMapping
 }
 


### PR DESCRIPTION
~~this fix makes sure the `name` property is directly defined in the `DataFilterResolver` prototype and is not inherited from another object up the chain~~

Implements the `EdmFilter.func` decorator and validates existing methods that are used as OData expressions in  `data-filter-resolver.js`

fixes: #257 