### PR TITLE
use an instance of a class as event listener

### DIFF
--- a/data-model.js
+++ b/data-model.js
@@ -610,10 +610,9 @@ function unregisterContextListeners() {
  * @private
  */
  function registerContextListeners() {
-
-    //description: change default max listeners (10) to 64 in order to avoid node.js message
-    // for reaching the maximum number of listeners
-    //author: k.barbounakis@gmail.com
+    // unregister listeners
+    unregisterContextListeners.call(this);
+    // set max listeners
     if (typeof this.setMaxListeners === 'function') {
         this.setMaxListeners(64);
     }
@@ -652,7 +651,7 @@ function unregisterContextListeners() {
     this.on('before.save', OnJsonAttribute.prototype.beforeSave);
     //get module loader
     /**
-     * @type {ModuleLoader|*}
+     * @type {ModuleLoaderStrategy}
      */
     var moduleLoader = this.context.getConfiguration().getStrategy(ModuleLoaderStrategy);
     //register configuration listeners
@@ -662,10 +661,25 @@ function unregisterContextListeners() {
             //get listener type (e.g. type: require('./custom-listener.js'))
             if (listener.type && !listener.disabled)
             {
+                const [listenerModule, listenerClassOrObject] = listener.type.split('#');
                 /**
                  * @type {{beforeSave?:function,afterSave?:function,beforeRemove?:function,afterRemove?:function,beforeExecute?:function,afterExecute?:function,beforeUpgrade?:function,afterUpgrade?:function}}
                  */
-                var dataEventListener = moduleLoader.require(listener.type);
+                let dataEventListener;
+                if (listenerClassOrObject) {
+                    const module =  moduleLoader.require(listenerModule);
+                    if (Object.prototype.hasOwnProperty.call(module, listenerClassOrObject) === false) {
+                        throw new DataError('ERR_TYPE_NOENT'`The event listener type "${listenerClassOrObject}" cannot be found in target module`, null, this.name);
+                    }
+                    if (isObjectDeep(module[listenerClassOrObject])) {
+                        dataEventListener = module[listenerClassOrObject];
+                    } else {
+                        const ListenerClass = module[listenerClassOrObject];
+                        dataEventListener = new ListenerClass();
+                    }
+                } else {
+                    dataEventListener = moduleLoader.require(listener.type);
+                }
                 if (typeof dataEventListener.beforeUpgrade === 'function')
                     this.on('before.upgrade', dataEventListener.beforeUpgrade);
                 if (typeof dataEventListener.beforeSave === 'function')

--- a/spec/DataModel.spec.ts
+++ b/spec/DataModel.spec.ts
@@ -3,6 +3,7 @@ import { TestApplication } from './TestApplication';
 import { resolve } from 'path';
 import {SqliteAdapter} from '@themost/sqlite';
 import * as listener from './test1/listeners/Employee.beforeUpgrade';
+import { OnUpdateProduct, onRemoveProduct } from './test1/listeners/OnUpdateProduct';
 
 class Employee {
     public EmployeeID?: number;
@@ -108,6 +109,7 @@ describe('DataModel', () => {
     });
 
     it('should use beforeUpgrade', async () => {
+        // @ts-ignore
         const schema: SchemaLoaderStrategy = context.getConfiguration().getStrategy(SchemaLoaderStrategy);
         const modelDefinition = schema.getModelDefinition('Employee')
         modelDefinition.eventListeners = modelDefinition.eventListeners || [];
@@ -122,6 +124,26 @@ describe('DataModel', () => {
         const [beforeUpgradeListener] = listeners;
         expect(beforeUpgradeListener).toBeTruthy();
         expect(beforeUpgradeListener).toBe(listener.beforeUpgrade);
+    });
+
+    it('should use class event listener', async () => {
+        const model = context.model('Product');
+        expect(model).toBeTruthy();
+        const listeners = model.listeners('before.save');
+        expect(listeners).toBeTruthy();
+        expect(listeners.length).toBeGreaterThan(0);
+        const found = listeners.find((f) => f === OnUpdateProduct.prototype.beforeSave);
+        expect(found).toBeTruthy();
+    });
+
+    it('should use object event listener', async () => {
+        const model = context.model('Product');
+        expect(model).toBeTruthy();
+        const listeners = model.listeners('before.remove');
+        expect(listeners).toBeTruthy();
+        expect(listeners.length).toBeGreaterThan(0);
+        const found = listeners.find((f) => f === onRemoveProduct.beforeRemove);
+        expect(found).toBeTruthy();
     });
 
 });

--- a/spec/test1/config/models/Product.json
+++ b/spec/test1/config/models/Product.json
@@ -41,6 +41,14 @@
             "nullable": false
         }
     ],
+    "eventListeners": [
+        {
+            "type": "./listeners/OnUpdateProduct#OnUpdateProduct"
+        },
+        {
+            "type": "./listeners/OnUpdateProduct#onRemoveProduct"
+        }
+    ],
     "seed": [
         {
             "ProductID": 1,

--- a/spec/test1/listeners/OnUpdateProduct.ts
+++ b/spec/test1/listeners/OnUpdateProduct.ts
@@ -1,0 +1,19 @@
+import {BeforeSaveEventListener, DataEventArgs} from '@themost/data';
+
+class OnUpdateProduct implements BeforeSaveEventListener {
+    beforeSave(_event: DataEventArgs, callback: (err?: Error) => void): void {
+        return callback();
+    }
+}
+
+// use a native object to export a listener
+const onRemoveProduct = {
+    beforeRemove: (_event: DataEventArgs, callback: (err?: Error) => void) => {
+        return callback();
+    }
+}
+
+export {
+    OnUpdateProduct,
+    onRemoveProduct
+}


### PR DESCRIPTION
This PR implements the usage of a class or a native object as event listener e.g.

```typescript
import {BeforeSaveEventListener, DataEventArgs} from '@themost/data';

class OnUpdateProduct implements BeforeSaveEventListener {
    beforeSave(_event: DataEventArgs, callback: (err?: Error) => void): void {
        return callback();
    }
}

// use a native object to export a listener
const onRemoveProduct = {
    beforeRemove: (_event: DataEventArgs, callback: (err?: Error) => void) => {
        return callback();
    }
}

export {
    OnUpdateProduct,
    onRemoveProduct
}
```
The `Product` model registers `OnUpdateProduct` or `onRemoveProduct` e.g.

```json
{
    "eventListeners": [
        {
            "type": "./listeners/OnUpdateProduct#OnUpdateProduct"
        },
        {
            "type": "./listeners/OnUpdateProduct#onRemoveProduct"
        }
    ]
}
```