### PR TITLE
fix: cb func returned as reference and is not invoked

### DIFF
--- a/data-permission.js
+++ b/data-permission.js
@@ -523,7 +523,7 @@ DataPermissionEventListener.prototype.validate = function (event, callback) {
                             // if privilege should be excluded
                             if (exclude === true) {
                                 // break
-                                return cb;
+                                return cb();
                             }
                             // otherwise, continue with permission validation
                             if (requestMask === PermissionMask.Create) {


### PR DESCRIPTION
`cb` is returned as a reference (`return cb;`) but should instead be invoked (`return cb();`)