### PR TITLE
handle null values returned by raw cache

### DIFF
--- a/data-cache.js
+++ b/data-cache.js
@@ -204,6 +204,9 @@ class DefaultDataCacheStrategy extends DataCacheStrategy {
             try {
                 void self.rawCache.get(key, (err, res) => {
                     if (typeof res !== 'undefined') {
+                        if (res === null) {
+                            return resolve(res);
+                        }
                         if (Object.prototype.hasOwnProperty.call(res, key)) {
                             return resolve(res[key]);
                         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/data",
-  "version": "2.23.7",
+  "version": "2.23.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/data",
-      "version": "2.23.7",
+      "version": "2.23.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/data",
-  "version": "2.23.7",
+  "version": "2.23.8",
   "description": "MOST Web Framework Codename Blueshift - Data module",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR updates `DefaultDataCacheStrategy` to handle a null value returned by the raw cache before return the result.